### PR TITLE
Expand CI To Include A Matrix of Rust Versions/LLVM Versions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,30 +5,87 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '00 4 * * *'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+         - "1.54"
+         - "1.55"
+         - "beta"
+         - "nightly"
+        llvm: ["12", "13", "rustc"]
+    name: "rustc: ${{ matrix.rust }}, llvm: ${{ matrix.llvm }}"
 
+    env:
+      CARGO_ARGS: ${{ matrix.llvm == 'rustc' && '--no-default-features --features rust-llvm' || '' }}
+      RUST_BACKTRACE: full
+    
     steps:
-    - uses: actions/checkout@v2
-    - uses: Swatinem/rust-cache@v1
-    - name: Install LLVM
-      run: |
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        echo -e "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main\n" | sudo tee /etc/apt/sources.list.d/llvm.list
-        sudo apt-get update
-        sudo apt-get install llvm-12-dev libclang-12-dev
+      - uses: actions/checkout@v2
 
-    - name: Build linking to external LLVM
-      run: cargo build --verbose
+      - name: Install Rust ${{ matrix.rust }}
+        if: matrix.rust != 'nightly'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
 
-    - name: Build linking to rustc's LLVM
-      run: cargo build --verbose --no-default-features --features rust-llvm
+      - uses: Swatinem/rust-cache@v1
+        if: matrix.rust != 'nightly'
 
-    - name: Run tests (rustc target = HOST_TARGET, link target = BPF)
-      run: TESTS_HOST_TARGET=1 RUST_BACKTRACE=full cargo test --verbose
+      - name: Checkout Rust Source
+        uses: actions/checkout@v2
+        if: matrix.rust == 'nightly'
+        with:
+          repository: rust-lang/rust
+          path: rust
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install rustup
+        if: matrix.rust == 'nightly'
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+      - name: Install Rust ${{ matrix.rust }} From Source
+        if: matrix.rust == 'nightly'
+        run: |
+          pushd rust
+          rm -rf build
+          echo -e 'profile = "user"\nchangelog-seen = 2\n\n[llvm]\ndownload-ci-llvm = true' > config.toml
+          ./x.py clean
+          ./x.py build -i --stage 2 --host x86_64-unknown-linux-gnu --target bpfel-unknown-none --target x86_64-unknown-linux-gnu library/std src/tools/rustdoc
+          rustup toolchain link stage2 build/x86_64-unknown-linux-gnu/stage2
+          popd
+          rustup override set stage2
+
+      - name: Install LLVM
+        if: matrix.llvm != 'rustc'
+        shell: bash
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo -e "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${{ matrix.llvm }} main\n" | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update
+          sudo apt-get install llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev
+
+      - name: Build
+        run: cargo build --verbose ${CARGO_ARGS}
+
+      - name: Test (rustc target = HOST_TARGET, link target = BPF)
+        env:
+          TESTS_HOST_TARGET: 1       
+        run: cargo test --verbose ${CARGO_ARGS}
+
+      - name: Tests (rustc target = BPF, link target = BPF)
+        if: matrix.rust == 'nightly'
+        env:
+          TESTS_HOST_TARGET: 0
+        run: cargo test --verbose ${CARGO_ARGS}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "simplelog",
  "structopt",
  "thiserror",
+ "which",
 ]
 
 [[package]]
@@ -248,6 +249,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "failure"
@@ -857,6 +864,17 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rustc-llvm-proxy = { path = "third-party/rustc-llvm-proxy", optional = true }
 
 [dev-dependencies]
 compiletest_rs = { version = "0.5", path = "third-party/compiletest-rs" }
+which = "4.2"
 
 [[bin]]
 name = "bpf-linker"

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
 extern crate compiletest_rs as compiletest;
 
+use which::which;
 use std::{env, path::PathBuf};
 
 fn run_mode(mode: &'static str) {
@@ -16,7 +17,13 @@ fn run_mode(mode: &'static str) {
         config.target = "bpfel-unknown-none".to_string();
     }
     config.target_rustcflags = Some(rustc_flags);
-    config.llvm_filecheck = Some("FileCheck-12".into());
+    if let Ok(filecheck) = which("FileCheck") {
+        config.llvm_filecheck = Some(filecheck)
+    } else if let Ok(filecheck) = which("FileCheck-12") {
+        config.llvm_filecheck = Some(filecheck)
+    } else {
+        panic!("no FileCheck binary found");
+    };
     config.mode = mode.parse().expect("Invalid mode");
     config.src_base = PathBuf::from(format!("tests/{}", mode));
     config.link_deps(); // Populate config.target_rustcflags with dependencies on the path


### PR DESCRIPTION
This uses `which` to ensure that we find a path to a "FileCheck|-12" binary, as well as adding LLVM12, LLVM13 and Rustc 1.54, 1.55, beta (1.56) and nightly (1.57) to the matrix.