### PR TITLE
Change the type of LLVM Message pointer to libc :: c_char

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "ar",
  "clap",
  "compiletest_rs",
+ "libc",
  "llvm-sys",
  "log",
  "rustc-llvm-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "2", optional = true }
 simplelog = {version = "0.7.6", optional = true}
 
 # lib deps
+libc = "0.2"
 thiserror = { version = "1.0", optional = true }
 ar = { version = "0.8", optional = true }
 log = { version = "0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![deny(clippy::all)]
 
+extern crate libc;
+
 mod llvm;
 mod linker;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![deny(clippy::all)]
 
-extern crate libc;
-
 mod llvm;
 mod linker;
 

--- a/src/llvm/message.rs
+++ b/src/llvm/message.rs
@@ -2,13 +2,14 @@ use std::ffi::CStr;
 use std::fmt;
 use std::ptr;
 
+use libc::c_char;
 use llvm_sys::core::LLVMDisposeMessage;
 
 /// Convinient LLVM Message pointer wrapper.
 /// Does not own the ptr, so we have to call `LLVMDisposeMessage` to free message memory.
 #[repr(C)]
 pub struct Message {
-    pub ptr: *mut ::libc::c_char,
+    pub ptr: *mut c_char,
 }
 
 impl Message {
@@ -22,7 +23,7 @@ impl Message {
         self.ptr.is_null()
     }
 
-    pub fn as_mut_ptr(&mut self) -> *mut *mut ::libc::c_char {
+    pub fn as_mut_ptr(&mut self) -> *mut *mut c_char {
         &mut self.ptr
     }
 }

--- a/src/llvm/message.rs
+++ b/src/llvm/message.rs
@@ -8,7 +8,7 @@ use llvm_sys::core::LLVMDisposeMessage;
 /// Does not own the ptr, so we have to call `LLVMDisposeMessage` to free message memory.
 #[repr(C)]
 pub struct Message {
-    pub ptr: *mut i8,
+    pub ptr: *mut ::libc::c_char,
 }
 
 impl Message {
@@ -22,7 +22,7 @@ impl Message {
         self.ptr.is_null()
     }
 
-    pub fn as_mut_ptr(&mut self) -> *mut *mut i8 {
+    pub fn as_mut_ptr(&mut self) -> *mut *mut ::libc::c_char {
         &mut self.ptr
     }
 }

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -64,7 +64,7 @@ pub unsafe fn find_embedded_bitcode(
 ) -> Result<Option<Vec<u8>>, String> {
     let buffer_name = CString::new("mem_buffer").unwrap();
     let buffer = LLVMCreateMemoryBufferWithMemoryRange(
-        data.as_ptr() as *const i8,
+        data.as_ptr() as *const ::libc::c_char,
         data.len() as usize,
         buffer_name.as_ptr(),
         0,
@@ -107,7 +107,7 @@ pub unsafe fn link_bitcode_buffer(
     let mut linked = false;
     let buffer_name = CString::new("mem_buffer").unwrap();
     let buffer = LLVMCreateMemoryBufferWithMemoryRange(
-        buffer.as_ptr() as *const i8,
+        buffer.as_ptr() as *const ::libc::c_char,
         buffer.len() as usize,
         buffer_name.as_ptr(),
         0,

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -8,6 +8,7 @@ use std::{
     ptr, slice,
 };
 
+use libc::c_char as libc_char;
 use llvm_sys::bit_reader::*;
 use llvm_sys::core::*;
 use llvm_sys::debuginfo::LLVMStripModuleDebugInfo;
@@ -64,7 +65,7 @@ pub unsafe fn find_embedded_bitcode(
 ) -> Result<Option<Vec<u8>>, String> {
     let buffer_name = CString::new("mem_buffer").unwrap();
     let buffer = LLVMCreateMemoryBufferWithMemoryRange(
-        data.as_ptr() as *const ::libc::c_char,
+        data.as_ptr() as *const libc_char,
         data.len() as usize,
         buffer_name.as_ptr(),
         0,
@@ -107,7 +108,7 @@ pub unsafe fn link_bitcode_buffer(
     let mut linked = false;
     let buffer_name = CString::new("mem_buffer").unwrap();
     let buffer = LLVMCreateMemoryBufferWithMemoryRange(
-        buffer.as_ptr() as *const ::libc::c_char,
+        buffer.as_ptr() as *const libc_char,
         buffer.len() as usize,
         buffer_name.as_ptr(),
         0,


### PR DESCRIPTION
When I tried to install it on Ubuntu, I got the following error.

```
error[E0308]: mismatched types
  --> src/llvm/message.rs:34:36
   |
34 |                 LLVMDisposeMessage(self.ptr);
   |                                    ^^^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*mut u8`
              found raw pointer `*mut i8`

error[E0308]: mismatched types
  --> src/llvm/message.rs:43:52
   |
43 |             let contents = unsafe { CStr::from_ptr(self.ptr).to_str().unwrap() };
   |                                                    ^^^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*const u8`
              found raw pointer `*mut i8`

// Many others
```

The reason was that the arguments of LLVMDisposeMessage and LLVMCreateBinary are libc :: c_char type instead of i8 type.