### PR TITLE
Ignore input objects that don't contain embedded bitcode

### DIFF
--- a/src/linker.rs
+++ b/src/linker.rs
@@ -273,7 +273,13 @@ impl Linker {
                 }
                 ty => {
                     info!("linking file {:?} type {}", path, ty);
-                    self.link_reader(&path, file, Some(ty))?;
+                    match self.link_reader(&path, file, Some(ty)) {
+                        Ok(_) => {}
+                        Err(LinkerError::MissingBitcodeSection(_)) => {
+                            warn!("ignoring file {:?}: no embedded bitcode", path);
+                        }
+                        err => return err,
+                    }
                 }
             }
         }


### PR DESCRIPTION
This case is only hit by tests when running with TESTS_HOST_TARGET=1, processing symbols.o. See
https://github.com/rust-lang/rust/commit/773f533eae25129cea7241b74e54f26ce5eebb62