### PR TITLE
fix: address clippy warnings

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
+          components: clippy
 
       - uses: Swatinem/rust-cache@v1
         if: matrix.rust != 'nightly'
@@ -77,6 +78,10 @@ jobs:
 
       - name: Build
         run: cargo build --verbose ${CARGO_ARGS}
+
+      - name: Lint
+        if: matrix.rust != 'nightly'
+        run: cargo clippy --verbose ${CARGO_ARGS} -- --deny warnings
 
       - name: Test (rustc target = HOST_TARGET, link target = BPF)
         env:

--- a/src/bin/bpf-linker.rs
+++ b/src/bin/bpf-linker.rs
@@ -135,20 +135,28 @@ struct CommandLine {
     #[structopt(long, value_name = "symbols", use_delimiter = true, multiple = true)]
     export: Vec<String>,
 
+    #[allow(dead_code)]
     #[structopt(short = "l", use_delimiter = true, multiple = true, hidden = true)]
     lib: Option<String>,
+    #[allow(dead_code)]
     #[structopt(long, hidden = true)]
     debug: bool,
+    #[allow(dead_code)]
     #[structopt(long, hidden = true)]
     rsp_quoting: Option<String>,
+    #[allow(dead_code)]
     #[structopt(long, hidden = true)]
     flavor: Option<String>,
+    #[allow(dead_code)]
     #[structopt(long, hidden = true)]
     no_entry: bool,
+    #[allow(dead_code)]
     #[structopt(long, hidden = true)]
     gc_sections: bool,
+    #[allow(dead_code)]
     #[structopt(long, hidden = true)]
     strip_debug: bool,
+    #[allow(dead_code)]
     #[structopt(long, hidden = true)]
     strip_all: bool,
 }

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -437,7 +437,7 @@ impl Linker {
     fn write_ir(&mut self, output: &CStr) -> Result<(), LinkerError> {
         info!("writing IR to {:?}", output);
 
-        unsafe { llvm::write_ir(self.module, &output) }.map_err(LinkerError::WriteIRError)
+        unsafe { llvm::write_ir(self.module, output) }.map_err(LinkerError::WriteIRError)
     }
 
     fn emit(&mut self, output: &CStr, output_type: LLVMCodeGenFileType) -> Result<(), LinkerError> {

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -35,7 +35,7 @@ pub unsafe fn init<T: AsRef<str>>(args: &[T], overview: &str) {
     LLVMInitializeBPFAsmPrinter();
     LLVMInitializeBPFDisassembler();
 
-    parse_command_line_options(&args, overview);
+    parse_command_line_options(args, overview);
 }
 
 unsafe fn parse_command_line_options<T: AsRef<str>>(args: &[T], overview: &str) {
@@ -138,7 +138,7 @@ pub unsafe fn target_from_triple(triple: &CStr) -> Result<LLVMTargetRef, String>
 
 pub unsafe fn target_from_module(module: LLVMModuleRef) -> Result<LLVMTargetRef, String> {
     let triple = LLVMGetTarget(module);
-    target_from_triple(&CStr::from_ptr(triple))
+    target_from_triple(CStr::from_ptr(triple))
 }
 
 pub unsafe fn create_target_machine(


### PR DESCRIPTION
Hello there :wave:, just fixing some minor warnings and enabling `clippy` in the CI :grin: 

<details>
<summary>Set 1</summary>

```
error: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/linker.rs:440:46
    |
440 |         unsafe { llvm::write_ir(self.module, &output) }.map_err(LinkerError::WriteIRError)
    |                                              ^^^^^^^ help: change this to: `output`
    |
note: the lint level is defined here
   --> src/lib.rs:1:9
    |
1   | #![deny(clippy::all)]
    |         ^^^^^^^^^^^
    = note: `#[deny(clippy::needless_borrow)]` implied by `#[deny(clippy::all)]`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/llvm/mod.rs:38:32
   |
38 |     parse_command_line_options(&args, overview);
   |                                ^^^^^ help: change this to: `args`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/llvm/mod.rs:141:24
    |
141 |     target_from_triple(&CStr::from_ptr(triple))
    |                        ^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `CStr::from_ptr(triple)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: could not compile `bpf-linker` due to 3 previous errors
```

</details>

<details>
<summary>Set 2</summary>

```
warning: multiple fields are never read
   --> src/bin/bpf-linker.rs:139:5
    |
61  | struct CommandLine {
    |        ----------- fields in this struct
...
139 |     lib: Option<String>,
    |     ^^^
140 |     #[structopt(long, hidden = true)]
141 |     debug: bool,
    |     ^^^^^
142 |     #[structopt(long, hidden = true)]
143 |     rsp_quoting: Option<String>,
    |     ^^^^^^^^^^^
144 |     #[structopt(long, hidden = true)]
145 |     flavor: Option<String>,
    |     ^^^^^^
146 |     #[structopt(long, hidden = true)]
147 |     no_entry: bool,
    |     ^^^^^^^^
148 |     #[structopt(long, hidden = true)]
149 |     gc_sections: bool,
    |     ^^^^^^^^^^^
150 |     #[structopt(long, hidden = true)]
151 |     strip_debug: bool,
    |     ^^^^^^^^^^^
152 |     #[structopt(long, hidden = true)]
153 |     strip_all: bool,
    |     ^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
    = note: `CommandLine` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis

warning: `bpf-linker` (bin "bpf-linker") generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
```

</details>