### PR TITLE
github: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:


### PR DESCRIPTION
202136fc39b66e60a6835074f3cc10781ca50f1c placed the configuration file
in .github/workflows, but it is supposed to be in .github.

