### PR TITLE
github: update actions/checkout to v3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
dependabot is barfing because lint.yml uses v2 while build-test.yml uses
v3. See https://github.com/aya-rs/bpf-linker/network/updates/671345293.
