### PR TITLE
github: update Swatinem/rust-cache@{v1,v2}

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: matrix.rust != 'nightly-from-source'
 
       - name: Checkout Rust Source


### PR DESCRIPTION
I don't understand why, but dependabot isn't updating this. See
https://github.com/dependabot/dependabot-core/issues/7384.
