### PR TITLE
Test on nightly-from-source only

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -91,14 +91,6 @@ jobs:
       - name: Build
         run: cargo hack build --feature-powerset
 
-      - name: Test (rustc target = HOST_TARGET, link target = BPF)
-        if: matrix.rust == 'nightly'
-        env:
-          TESTS_HOST_TARGET: 1
-        run: cargo hack test --feature-powerset
-
-      - name: Tests (rustc target = BPF, link target = BPF)
+      - name: Test
         if: matrix.rust == 'nightly-from-source'
-        env:
-          TESTS_HOST_TARGET: 0
         run: cargo hack test --feature-powerset

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,25 +5,8 @@ use which::which;
 
 fn run_mode(mode: &'static str) {
     let mut config = compiletest::Config::default();
-
-    let mut rustc_flags = format!("-C linker={}", env!("CARGO_BIN_EXE_bpf-linker"));
-    // Default to the host target backdoor so that tests can run locally without building rustc from source.
-    let host_target = env::var_os("TESTS_HOST_TARGET").map_or(true, |v| v == "1");
-    if host_target {
-        rustc_flags = [
-            rustc_flags.as_str(),
-            "-C link-arg=--target=bpf",
-            "-C linker-flavor=bpf-linker",
-            "-C linker-plugin-lto",
-            "-C panic=abort",
-            "-C target-cpu=generic",
-            "-Z unstable-options",
-        ]
-        .join(" ");
-    } else {
-        config.target = "bpfel-unknown-none".to_string();
-    }
-    config.target_rustcflags = Some(rustc_flags);
+    config.target = "bpfel-unknown-none".to_string();
+    config.target_rustcflags = Some(format!("-C linker={}", env!("CARGO_BIN_EXE_bpf-linker")));
     if let Ok(filecheck) = which("FileCheck") {
         config.llvm_filecheck = Some(filecheck)
     } else if let Ok(filecheck) = which("FileCheck-16") {


### PR DESCRIPTION
This continues from bbeeae567ae937a1d14602240e7ffbb607d03054; now that
https://github.com/rust-lang/rust/commit/b0ce4164f09be1221d004c4b84e49bdcbf973194
has made its way to the nightly channel, we can no longer use the host
target backdoor at all; all compiletest tests must run on a toolchain
that supports bpf.
