### PR TITLE
Add flag to treat LLVM errors as fatal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ rust-llvm = [
     "llvm-sys/disable-alltargets-init"
 ]
 default = ["rust-llvm"]
+
+[profile.release]
+debug = true

--- a/src/llvm/iter.rs
+++ b/src/llvm/iter.rs
@@ -4,67 +4,81 @@ use llvm_sys::core::*;
 use llvm_sys::prelude::*;
 
 macro_rules! llvm_iterator {
-    ($trait_name:ident, $iterator_name:ident, $iterable:ty, $method_name:ident, $item_ty:ty, $first:expr, $next:expr) => {
+    ($trait_name:ident, $iterator_name:ident, $iterable:ty, $method_name:ident, $item_ty:ty, $first:expr, $last:expr, $next:expr $(,)?) => {
         pub trait $trait_name {
             fn $method_name(&self) -> $iterator_name;
         }
 
-        impl $trait_name for $iterable {
-            fn $method_name(&self) -> $iterator_name {
-                $iterator_name {
-                    iterable: PhantomData,
-                    next: unsafe { $first(*self) },
-                }
-            }
+        pub struct $iterator_name<'a> {
+            lifetime: PhantomData<&'a $iterable>,
+            next: $item_ty,
+            last: $item_ty,
         }
 
-        pub struct $iterator_name<'a> {
-            iterable: PhantomData<&'a $iterable>,
-            next: $item_ty,
+        impl $trait_name for $iterable {
+            fn $method_name(&self) -> $iterator_name {
+                let first = unsafe { $first(*self) };
+                let last = unsafe { $last(*self) };
+                assert_eq!(first.is_null(), last.is_null());
+                $iterator_name {
+                    lifetime: PhantomData,
+                    next: first,
+                    last,
+                }
+            }
         }
 
         impl<'a> Iterator for $iterator_name<'a> {
             type Item = $item_ty;
 
             fn next(&mut self) -> Option<Self::Item> {
-                let next = self.next;
-                if !next.is_null() {
-                    self.next = unsafe { $next(next) };
-                    Some(next)
-                } else {
-                    None
+                let Self {
+                    lifetime: _,
+                    next,
+                    last,
+                } = self;
+                if next.is_null() {
+                    return None;
                 }
+                let last = *next == *last;
+                let item = *next;
+                *next = unsafe { $next(*next) };
+                assert_eq!(next.is_null(), last);
+                Some(item)
             }
         }
     };
 }
 
-llvm_iterator!(
-    IterModuleFunctions,
-    FunctionsIter,
-    LLVMModuleRef,
-    functions_iter,
-    LLVMValueRef,
-    LLVMGetFirstFunction,
-    LLVMGetNextFunction
-);
-
-llvm_iterator!(
+llvm_iterator! {
     IterModuleGlobals,
     GlobalsIter,
     LLVMModuleRef,
     globals_iter,
     LLVMValueRef,
     LLVMGetFirstGlobal,
-    LLVMGetNextGlobal
-);
+    LLVMGetLastGlobal,
+    LLVMGetNextGlobal,
+}
 
-llvm_iterator!(
+llvm_iterator! {
     IterModuleGlobalAliases,
-    GlobalAliasessIter,
+    GlobalAliasesIter,
     LLVMModuleRef,
     global_aliases_iter,
     LLVMValueRef,
     LLVMGetFirstGlobalAlias,
-    LLVMGetNextGlobalAlias
-);
+    LLVMGetLastGlobalAlias,
+    LLVMGetNextGlobalAlias,
+}
+
+llvm_iterator! {
+    IterModuleFunctions,
+    FunctionsIter,
+    LLVMModuleRef,
+    functions_iter,
+    LLVMValueRef,
+    LLVMGetFirstFunction,
+    LLVMGetLastFunction,
+    LLVMGetNextFunction,
+}

--- a/src/llvm/message.rs
+++ b/src/llvm/message.rs
@@ -15,6 +15,10 @@ impl Message {
         }
     }
 
+    pub fn from_ptr(ptr: *mut c_char) -> Self {
+        Self { ptr }
+    }
+
     pub fn as_c_str(&self) -> Option<&CStr> {
         let Self { ptr } = self;
         if !ptr.is_null() {

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -74,9 +74,9 @@ pub unsafe fn find_embedded_bitcode(
     );
 
     let mut message = Message::new();
-    let bin = LLVMCreateBinary(buffer, ptr::null_mut(), message.as_mut_ptr());
+    let bin = LLVMCreateBinary(buffer, ptr::null_mut(), &mut *message);
     if bin.is_null() {
-        return Err(message.to_string());
+        return Err(message.as_c_str().unwrap().to_str().unwrap().to_string());
     }
 
     let mut ret = None;
@@ -131,8 +131,8 @@ pub unsafe fn target_from_triple(triple: &CStr) -> Result<LLVMTargetRef, String>
     let mut target = ptr::null_mut();
     let mut message = Message::new();
 
-    if LLVMGetTargetFromTriple(triple.as_ptr(), &mut target, message.as_mut_ptr()) == 1 {
-        return Err(message.to_string());
+    if LLVMGetTargetFromTriple(triple.as_ptr(), &mut target, &mut *message) == 1 {
+        return Err(message.as_c_str().unwrap().to_str().unwrap().to_string());
     }
 
     Ok(target)
@@ -269,8 +269,8 @@ unsafe fn remove_attribute(function: *mut llvm_sys::LLVMValue, name: &str) {
 
 pub unsafe fn write_ir(module: LLVMModuleRef, output: &CStr) -> Result<(), String> {
     let mut message = Message::new();
-    if LLVMPrintModuleToFile(module, output.as_ptr(), message.as_mut_ptr()) == 1 {
-        return Err(message.to_string());
+    if LLVMPrintModuleToFile(module, output.as_ptr(), &mut *message) == 1 {
+        return Err(message.as_c_str().unwrap().to_str().unwrap().to_string());
     }
 
     Ok(())
@@ -289,10 +289,10 @@ pub unsafe fn codegen(
         module,
         output.as_ptr() as *mut _,
         output_type,
-        message.as_mut_ptr(),
+        &mut *message,
     ) == 1
     {
-        return Err(message.to_string());
+        return Err(message.as_c_str().unwrap().to_str().unwrap().to_string());
     }
 
     Ok(())


### PR DESCRIPTION
This is apparently the contract we're supposed to uphold. Currently we sometimes miscompile things.
