### PR TITLE
fixed lto flag in BTF tests

### DIFF
--- a/tests/btf/assembly/basic.rs
+++ b/tests/btf/assembly/basic.rs
@@ -1,6 +1,6 @@
 // assembly-output: bpf-linker
 // no-prefer-dynamic
-// compile-flags: --crate-type bin -C link-arg=--emit=obj -C debuginfo=2 -C lto=true
+// compile-flags: --crate-type bin -C link-arg=--emit=obj -C debuginfo=2
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
There was lto=true inside BTF test, which hides some bugs encountered in the linker.
In order to be able to remove `lto=true` in BTF tests, a new sysroot built with DI needs to be used. The reason for this is a bug in LLVM which prevents to have code with DI and code without DI built together.

NB: we cannot use a single sysroot built with DI for all the tests (BTF + assembly) because assembly tests are crashing the linker when built with DI.
