### PR TITLE
build tests sysroot with DI

### DIFF
--- a/tests/assembly/ignore-inline-never.rs
+++ b/tests/assembly/ignore-inline-never.rs
@@ -21,6 +21,6 @@ fn actually_inlined(a: u64) -> u64 {
 pub extern "C" fn fun(a: u64) -> u64 {
     // CHECK-LABEL: fun:
     actually_inlined(a)
-    // CHECK-NEXT: r{{[0-9]}} = r{{[0-9]}}
+    // CHECK: r{{[0-9]}} = r{{[0-9]}}
     // CHECK-NEXT: r{{[0-9]}} += 42
 }

--- a/tests/btf/assembly/basic.rs
+++ b/tests/btf/assembly/basic.rs
@@ -1,0 +1,18 @@
+// assembly-output: bpf-linker
+// no-prefer-dynamic
+// compile-flags: --crate-type bin -C link-arg=--emit=obj -C debuginfo=2
+
+#![no_std]
+#![no_main]
+
+#[no_mangle]
+#[link_section = "uprobe/connect"]
+pub fn connect() {}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+// We check the BTF dump out of bpftool
+// CHECK: FUNC 'connect' type_id=1 linkage=global

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -46,6 +46,7 @@ fn compile_test() {
     let () = rustc_build_sysroot::SysrootBuilder::new(&directory, target)
         .build_mode(rustc_build_sysroot::BuildMode::Build)
         .sysroot_config(rustc_build_sysroot::SysrootConfig::NoStd)
+        .rustflag("-Cdebuginfo=2")
         .build_from_source(&rustc_src)
         .expect("failed to build sysroot");
 


### PR DESCRIPTION
Build tests sysroot with DI:

    fixed ignore-inline-never.rs that is failing because of FileCheck matching DI instead of expected check
    removed lto=true from BTF tests

NB: this requires patched LLVM https://github.com/rust-lang/llvm-project/commit/d06f0cd0977dd16f09c259133f36c7e8b9f0d322