### PR TITLE
build tests sysroot with DI

### DIFF
--- a/tests/assembly/ignore-inline-never.rs
+++ b/tests/assembly/ignore-inline-never.rs
@@ -21,6 +21,6 @@ fn actually_inlined(a: u64) -> u64 {
 pub extern "C" fn fun(a: u64) -> u64 {
     // CHECK-LABEL: fun:
     actually_inlined(a)
-    // CHECK-NEXT: r{{[0-9]}} = r{{[0-9]}}
+    // CHECK: r{{[0-9]}} = r{{[0-9]}}
     // CHECK-NEXT: r{{[0-9]}} += 42
 }

--- a/tests/btf/assembly/basic.rs
+++ b/tests/btf/assembly/basic.rs
@@ -1,6 +1,6 @@
 // assembly-output: bpf-linker
 // no-prefer-dynamic
-// compile-flags: --crate-type bin -C link-arg=--emit=obj -C debuginfo=2 -C lto=true
+// compile-flags: --crate-type bin -C link-arg=--emit=obj -C debuginfo=2
 
 #![no_std]
 #![no_main]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -72,6 +72,7 @@ fn compile_test() {
     let () = rustc_build_sysroot::SysrootBuilder::new(&directory, target)
         .build_mode(rustc_build_sysroot::BuildMode::Build)
         .sysroot_config(rustc_build_sysroot::SysrootConfig::NoStd)
+        .rustflag("-Cdebuginfo=2")
         .build_from_source(&rustc_src)
         .expect("failed to build sysroot");
 


### PR DESCRIPTION
This is a rebased version of PR https://github.com/aya-rs/bpf-linker/pull/99

* fixed ignore-inline-never.rs that is failing because of FileCheck matching DI instead of expected check
* removed lto=true from BTF tests
* a fix for a NULL ptr use with DIFlagFwdDecl (had to be integrated in this PR otherwise Nightly tests are failing)

NB: this requires patched LLVM https://github.com/rust-lang/llvm-project/commit/d06f0cd0977dd16f09c259133f36c7e8b9f0d322