### PR TITLE
di: Avoid null pointer dereference when accessing DIType name

### DIFF
--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -14,11 +14,35 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
 use std::ffi::CStr;
 use std::hash::Hasher;
+use std::ptr::NonNull;
 
 // KSYM_NAME_LEN from linux kernel intentionally set
 // to lower value found accross kernel versions to ensure
 // backward compatibility
 const MAX_KSYM_NAME_LEN: usize = 128;
+
+pub struct DIType {
+    metadata: LLVMMetadataRef,
+}
+
+impl DIType {
+    pub fn new(metadata: LLVMMetadataRef) -> Self {
+        Self { metadata }
+    }
+
+    pub fn name(&self) -> Option<&CStr> {
+        let mut len = 0;
+        // `LLVMDITypeGetName` doesn't allocate any memory, it just returns
+        // an existing pointer:
+        // https://github.com/llvm/llvm-project/blob/eee1f7cef856241ad7d66b715c584d29b1c89ca9/llvm/lib/IR/DebugInfo.cpp#L1489-L1493
+        //
+        // Therefore, we don't need to call `LLVMDisposeMessage`. The memory
+        // gets freed when calling `LLVMDisposeDIBuilder`. Example:
+        // https://github.com/llvm/llvm-project/blob/eee1f7cef856241ad7d66b715c584d29b1c89ca9/llvm/tools/llvm-c-test/debuginfo.c#L249-L255
+        let ptr = unsafe { LLVMDITypeGetName(self.metadata, &mut len) };
+        NonNull::new(ptr as *mut _).map(|ptr| unsafe { CStr::from_ptr(ptr.as_ptr()) })
+    }
+}
 
 pub struct DIFix {
     context: LLVMContextRef,
@@ -69,6 +93,7 @@ impl DIFix {
 
     unsafe fn mdnode(&mut self, value: LLVMValueRef) {
         let metadata = LLVMValueAsMetadata(value);
+        let di_type = DIType::new(metadata);
         let metadata_kind = LLVMGetMetadataKind(metadata);
 
         let empty = to_mdstring(self.context, "");
@@ -81,19 +106,17 @@ impl DIFix {
                 #[allow(non_upper_case_globals)]
                 match tag {
                     DW_TAG_structure_type => {
-                        let mut len = 0;
-                        let name = CStr::from_ptr(LLVMDITypeGetName(metadata, &mut len))
-                            .to_str()
-                            .unwrap();
-
-                        if name.starts_with("HashMap<") {
-                            // Remove name from BTF map structs.
-                            LLVMReplaceMDNodeOperandWith(value, 2, empty);
-                        } else {
-                            // Clear the name from generics.
-                            let name = sanitize_type_name(name);
-                            let name = to_mdstring(self.context, &name);
-                            LLVMReplaceMDNodeOperandWith(value, 2, name);
+                        if let Some(name) = di_type.name() {
+                            let name = name.to_string_lossy();
+                            if name.starts_with("HashMap<") {
+                                // Remove name from BTF map structs.
+                                LLVMReplaceMDNodeOperandWith(value, 2, empty);
+                            } else {
+                                // Clear the name from generics.
+                                let name = sanitize_type_name(name);
+                                let name = to_mdstring(self.context, &name);
+                                LLVMReplaceMDNodeOperandWith(value, 2, name);
+                            }
                         }
 
                         // variadic enum not supported => emit warning and strip out the children array
@@ -117,16 +140,6 @@ impl DIFix {
                             let element = LLVMGetOperand(elements, i);
                             let tag = get_tag(LLVMValueAsMetadata(element));
                             if i == 0 && tag == DW_TAG_variant_part {
-                                let link = "http://none-yet";
-
-                                let mut len = 0;
-                                let name = CStr::from_ptr(LLVMDITypeGetName(
-                                    LLVMValueAsMetadata(value),
-                                    &mut len,
-                                ))
-                                .to_str()
-                                .unwrap();
-
                                 // TODO: check: the following always returns <unknown>:0 - however its strange...
                                 let _line = LLVMDITypeGetLine(LLVMValueAsMetadata(value)); // always returns 0
                                 let scope = LLVMDIVariableGetScope(metadata);
@@ -175,10 +188,20 @@ impl DIFix {
                                     .unwrap_or(("unknown", 0));
 
                                 // finally emit warning
-                                warn!(
-                                    "at {}:{}: enum {}: not emitting BTF for type - see {}",
-                                    filename, line, name, link
-                                );
+                                match di_type.name() {
+                                    Some(name) => warn!(
+                                        "not emitting BTF for type {} at {}:{}",
+                                        name.to_string_lossy(),
+                                        filename,
+                                        line
+                                    ),
+                                    None => {
+                                        warn!(
+                                            "not emitting BTF for anonymous type at {}:{}",
+                                            filename, line
+                                        )
+                                    }
+                                }
 
                                 // strip out children
                                 let empty_node =
@@ -225,15 +248,12 @@ impl DIFix {
             }
             // Sanitize function (subprogram) names.
             LLVMMetadataKind::LLVMDISubprogramMetadataKind => {
-                let mut len = 0;
-                let name = CStr::from_ptr(LLVMDITypeGetName(metadata, &mut len))
-                    .to_str()
-                    .unwrap();
-
-                // Clear the name from generics.
-                let name = sanitize_type_name(name);
-                let name = to_mdstring(self.context, &name);
-                LLVMReplaceMDNodeOperandWith(value, 2, name);
+                if let Some(name) = di_type.name() {
+                    // Clear the name from generics.
+                    let name = sanitize_type_name(name.to_string_lossy());
+                    let name = to_mdstring(self.context, &name);
+                    LLVMReplaceMDNodeOperandWith(value, 2, name);
+                }
             }
             _ => (),
         }

--- a/tests/btf/assembly/anon_struct_c.rs
+++ b/tests/btf/assembly/anon_struct_c.rs
@@ -1,0 +1,41 @@
+//! Check if bpf-linker is able to link bitcode which provides anonymous structs
+//! exposed by named typedefs. The corresponding C code is available in
+//! tests/c/anon.c.
+
+// assembly-output: bpf-linker
+// compile-flags: --crate-type bin -C link-arg=--emit=obj -C debuginfo=2 -Z unstable-options -L native=target/bitcode -l link-arg=target/bitcode/anon.bc
+
+#![no_std]
+#![no_main]
+
+#[no_mangle]
+static EXPECTED_FOO: i32 = 0;
+
+/// A binding to the struct from C code.
+///
+/// In Rust, there is no concept of anonymous structs and typedef aliases
+/// (`type` in Rust works differently and also produces different debug info).
+/// Just defining a named struct is a correct way of creating a binding and
+/// that's exactly what bindgen does.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Incognito {
+    pub foo: i32,
+}
+
+extern "C" {
+    pub fn incognito_foo(i: *const Incognito) -> i32;
+}
+
+#[no_mangle]
+pub fn get_foo(i: *const Incognito) -> i32 {
+    unsafe { incognito_foo(i) }
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+// CHECK: [9] TYPEDEF 'incognito' type_id=10
+// CHECK: [10] STRUCT '(anon)' size=4 vlen=1

--- a/tests/c/anon.c
+++ b/tests/c/anon.c
@@ -1,0 +1,10 @@
+/**
+ * An anonymous struct aliased with a typedef.
+ */
+typedef struct {
+  int foo;
+} incognito;
+
+int incognito_foo(incognito *i) {
+  return __builtin_preserve_access_index(i->foo);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,9 +1,18 @@
 use std::{
     env,
-    ffi::OsString,
+    ffi::{OsStr, OsString},
+    fs,
     path::{Path, PathBuf},
     process::Command,
 };
+
+fn find_binary(binary_re_str: &str) -> PathBuf {
+    let binary_re = regex::Regex::new(binary_re_str).unwrap();
+    let mut binary = which::which_re(binary_re).expect(binary_re_str);
+    binary
+        .next()
+        .unwrap_or_else(|| panic!("could not find {binary_re_str}"))
+}
 
 fn run_mode<F: Fn(&mut compiletest_rs::Config)>(
     target: &str,
@@ -17,14 +26,7 @@ fn run_mode<F: Fn(&mut compiletest_rs::Config)>(
         target_rustcflags += &format!(" --sysroot {sysroot}");
     }
 
-    let llvm_filecheck_re_str = r"^FileCheck(-\d+)?$";
-    let llvm_filecheck_re = regex::Regex::new(llvm_filecheck_re_str).unwrap();
-    let mut llvm_filecheck = which::which_re(llvm_filecheck_re).expect(llvm_filecheck_re_str);
-    let llvm_filecheck = llvm_filecheck.next();
-    assert_ne!(
-        llvm_filecheck, None,
-        "Could not find {llvm_filecheck_re_str}"
-    );
+    let llvm_filecheck = Some(find_binary(r"^FileCheck(-\d+)?$"));
 
     let mode = mode.parse().expect("Invalid mode");
     let mut config = compiletest_rs::Config {
@@ -42,6 +44,53 @@ fn run_mode<F: Fn(&mut compiletest_rs::Config)>(
     }
 
     compiletest_rs::run_tests(&config);
+}
+
+/// Builds LLVM bitcode files from LLVM IR files located in a specified directory.
+fn build_bitcode<P>(src_dir: P, dst_dir: P)
+where
+    P: AsRef<Path>,
+{
+    fs::create_dir_all(dst_dir.as_ref()).expect("failed to create a build directory for bitcode");
+    for entry in fs::read_dir(src_dir.as_ref()).expect("failed to read the directory") {
+        let entry = entry.expect("failed to read the entry");
+        let path = entry.path();
+
+        if path.is_file() && path.extension() == Some(OsStr::new("c")) {
+            let bc_dst = dst_dir
+                .as_ref()
+                .join(path.with_extension("bc").file_name().unwrap());
+            clang_build(path, bc_dst);
+        }
+    }
+}
+
+/// Compiles C code into an LLVM bitcode file.
+fn clang_build<P>(src: P, dst: P)
+where
+    P: AsRef<Path>,
+{
+    let clang = find_binary(r"^clang(-\d+)?$");
+    let output = Command::new(clang)
+        .arg("-target")
+        .arg("bpf")
+        .arg("-g")
+        .arg("-c")
+        .arg("-emit-llvm")
+        .arg("-o")
+        .arg(dst.as_ref())
+        .arg(src.as_ref())
+        .output()
+        .expect("failed to execute clang");
+
+    if !output.status.success() {
+        panic!(
+            "clang failed with code {:?}\nstdout: {}\nstderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }
 
 fn btf_dump(src: &Path, dst: &Path) {
@@ -67,8 +116,10 @@ fn compile_test() {
         std::process::Command::new(env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc")));
     let rustc_src = rustc_build_sysroot::rustc_sysroot_src(rustc)
         .expect("could not determine sysroot source directory");
-    let mut directory = env::current_dir().expect("could not determine current directory");
-    directory.push("target/sysroot");
+    let root_dir = env::var_os("CARGO_MANIFEST_DIR")
+        .expect("could not determine the root directory of the project");
+    let root_dir = Path::new(&root_dir);
+    let directory = root_dir.join("target/sysroot");
     let () = rustc_build_sysroot::SysrootBuilder::new(&directory, target)
         .build_mode(rustc_build_sysroot::BuildMode::Build)
         .sysroot_config(rustc_build_sysroot::SysrootConfig::NoStd)
@@ -77,6 +128,8 @@ fn compile_test() {
         .rustflag("-Cdebuginfo=2")
         .build_from_source(&rustc_src)
         .expect("failed to build sysroot");
+
+    build_bitcode(root_dir.join("tests/c"), root_dir.join("target/bitcode"));
 
     run_mode(
         target,


### PR DESCRIPTION
Before this change, an anonymous C struct present in a shim (written in C), linked by bpf-linker to a Rust program, would trigger a null dereference. An example of a struct triggering it is:

```c
typedef struct {
  int counter;
} atomic_t;
```

To avoid such footguns, provide a helper function for getting the DIType name safely.

Fixes: #130

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/120)
<!-- Reviewable:end -->
