### PR TITLE
Cargo.toml: remove aya-rustc-llvm-proxy feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ name = "bpf-linker"
 
 [features]
 rust-llvm = [
-    "aya-rustc-llvm-proxy",
+    "dep:aya-rustc-llvm-proxy",
     "llvm-sys/no-llvm-linking",
     "llvm-sys/disable-alltargets-init",
 ]


### PR DESCRIPTION
This doesn't make sense as a standalone feature.