### PR TITLE
chore: Avoid `*` imports

### DIFF
--- a/src/bin/bpf-linker.rs
+++ b/src/bin/bpf-linker.rs
@@ -14,7 +14,7 @@ use std::{
 use bpf_linker::{Cpu, Linker, LinkerOptions, OptLevel, OutputType};
 use clap::Parser;
 use libc::dup2;
-use log::*;
+use log::info;
 use simplelog::{
     ColorChoice, Config, LevelFilter, SimpleLogger, TermLogger, TerminalMode, WriteLogger,
 };

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -12,9 +12,16 @@ use std::{
 
 use ar::Archive;
 use llvm_sys::{
-    bit_writer::LLVMWriteBitcodeToFile, core::*, error_handling::*, prelude::*, target_machine::*,
+    bit_writer::LLVMWriteBitcodeToFile,
+    core::{
+        LLVMContextCreate, LLVMContextDispose, LLVMContextSetDiagnosticHandler, LLVMDisposeModule,
+        LLVMGetTarget,
+    },
+    error_handling::{LLVMEnablePrettyStackTrace, LLVMInstallFatalErrorHandler},
+    prelude::{LLVMContextRef, LLVMModuleRef},
+    target_machine::{LLVMCodeGenFileType, LLVMDisposeTargetMachine, LLVMTargetMachineRef},
 };
-use log::*;
+use log::{debug, error, info, warn};
 use thiserror::Error;
 
 use crate::llvm;

--- a/src/llvm/iter.rs
+++ b/src/llvm/iter.rs
@@ -1,6 +1,13 @@
 use std::marker::PhantomData;
 
-use llvm_sys::{core::*, prelude::*};
+use llvm_sys::{
+    core::{
+        LLVMGetFirstFunction, LLVMGetFirstGlobal, LLVMGetFirstGlobalAlias, LLVMGetLastFunction,
+        LLVMGetLastGlobal, LLVMGetLastGlobalAlias, LLVMGetNextFunction, LLVMGetNextGlobal,
+        LLVMGetNextGlobalAlias,
+    },
+    prelude::{LLVMModuleRef, LLVMValueRef},
+};
 
 macro_rules! llvm_iterator {
     ($trait_name:ident, $iterator_name:ident, $iterable:ty, $method_name:ident, $item_ty:ty, $first:expr, $last:expr, $next:expr $(,)?) => {

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -11,12 +11,41 @@ use std::{
 use iter::{IterModuleFunctions, IterModuleGlobalAliases, IterModuleGlobals};
 use libc::c_char as libc_char;
 use llvm_sys::{
-    bit_reader::*, core::*, debuginfo::LLVMStripModuleDebugInfo, error::*,
-    linker::LLVMLinkModules2, object::*, prelude::*, support::LLVMParseCommandLineOptions,
-    target::*, target_machine::*, transforms::pass_builder::*, LLVMAttributeFunctionIndex,
-    LLVMLinkage, LLVMVisibility,
+    bit_reader::LLVMParseBitcodeInContext2,
+    core::{
+        LLVMCreateMemoryBufferWithMemoryRange, LLVMDisposeMemoryBuffer, LLVMDisposeMessage,
+        LLVMGetDiagInfoDescription, LLVMGetDiagInfoSeverity, LLVMGetEnumAttributeKindForName,
+        LLVMGetModuleInlineAsm, LLVMGetTarget, LLVMGetValueName2,
+        LLVMModuleCreateWithNameInContext, LLVMPrintModuleToFile, LLVMRemoveEnumAttributeAtIndex,
+        LLVMSetLinkage, LLVMSetModuleInlineAsm2, LLVMSetVisibility,
+    },
+    debuginfo::LLVMStripModuleDebugInfo,
+    error::{
+        LLVMDisposeErrorMessage, LLVMGetErrorMessage, LLVMGetErrorTypeId, LLVMGetStringErrorTypeId,
+    },
+    linker::LLVMLinkModules2,
+    object::{
+        LLVMCreateBinary, LLVMDisposeBinary, LLVMDisposeSectionIterator, LLVMGetSectionContents,
+        LLVMGetSectionName, LLVMGetSectionSize, LLVMMoveToNextSection,
+        LLVMObjectFileCopySectionIterator, LLVMObjectFileIsSectionIteratorAtEnd,
+    },
+    prelude::{LLVMContextRef, LLVMDiagnosticInfoRef, LLVMModuleRef, LLVMValueRef},
+    support::LLVMParseCommandLineOptions,
+    target::{
+        LLVMInitializeBPFAsmParser, LLVMInitializeBPFAsmPrinter, LLVMInitializeBPFDisassembler,
+        LLVMInitializeBPFTarget, LLVMInitializeBPFTargetInfo, LLVMInitializeBPFTargetMC,
+    },
+    target_machine::{
+        LLVMCodeGenFileType, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMCreateTargetMachine,
+        LLVMGetTargetFromTriple, LLVMRelocMode, LLVMTargetMachineEmitToFile, LLVMTargetMachineRef,
+        LLVMTargetRef,
+    },
+    transforms::pass_builder::{
+        LLVMCreatePassBuilderOptions, LLVMDisposePassBuilderOptions, LLVMRunPasses,
+    },
+    LLVMAttributeFunctionIndex, LLVMLinkage, LLVMVisibility,
 };
-use log::*;
+use log::{debug, error};
 
 use crate::OptLevel;
 


### PR DESCRIPTION
Related to discussion on #142, import `llvm-sys` types explicitly.