### PR TITLE
Always set feature `llvm-sys/disable-alltargets-init`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ simplelog = { version = "0.12.1" }
 ar = { version = "0.9.0" }
 aya-rustc-llvm-proxy = { version = "0.9.0", optional = true }
 libc = { version = "0.2.150" }
-llvm-sys = { version = "170.0.0" }
+llvm-sys = { features = ["disable-alltargets-init"], version = "170.0.0" }
 log = { version = "0.4.20" }
 thiserror = { version = "1.0.50" }
 


### PR DESCRIPTION
From https://gitlab.com/taricorp/llvm-sys.rs/-/blob/main/README.md?ref_type=heads#cargo-features:

> `disable-alltargets-init`: disable building the functions that initialize
LLVM components for all supported targets. These functions need to be
compiled from C, so if they are unneeded then turning them off can allow
the build to proceed if a working C compiler is unavailable.

Currently, this feature is disabled if building without default features, like with for instance non-Linux, x86_64. But this feature is applicable regardless of how LLVM is linked to.