### PR TITLE
di: Sanitize data carrying enums correctly

### DIFF
--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -567,20 +567,17 @@ impl DISanitizer {
                             return;
                         }
 
-                        // variadic enum not supported => emit warning and strip out the children array
-                        // i.e. pub enum Foo { Bar, Baz(u32), Bad(u64, u64) }
-
-                        // we detect this is a variadic enum if the child element is a DW_TAG_variant_part
+                        let mut is_data_carrying_enum = false;
                         let mut members = Vec::new();
                         for element in di_composite_type.elements() {
                             match element.into_metadata_kind() {
-                                MetadataKind::DICompositeType(mut di_composite_type) => {
-                                    // The presence of `DW_TAG_variant_part` in a composite type
-                                    // means that we are processing a data-carrying enum. Such
-                                    // type is not supported by the Linux kernel, so we need to
-                                    // remove the children, so BTF doesn't contain data carried
-                                    // by the enum variant.
-                                    match di_composite_type.di_type.di_scope.di_node.tag() {
+                                MetadataKind::DICompositeType(di_composite_type_inner) => {
+                                    // The presence of a composite type with `DW_TAG_variant_part`
+                                    // as a member of another composite type means that we are
+                                    // processing a data-carrying enum. Such types are not supported
+                                    // by the Linux kernel. We need to remove the children, so BTF
+                                    // doesn't contain data carried by the enum variant.
+                                    match di_composite_type_inner.di_type.di_scope.di_node.tag() {
                                         DW_TAG_variant_part => {
                                             let line = di_composite_type.di_type.line();
                                             let file = di_composite_type
@@ -601,19 +598,12 @@ impl DISanitizer {
                                             };
 
                                             warn!(
-                                                "at {}:{}: enum {}: not emitting BTF",
-                                                filename, line, name
+                                                "found data carrying enum {name} ({filename}:{line}), not emitting
+                                                the debug info for it"
                                             );
 
-                                            // Remove children.
-                                            // TODO(vadorovsky): We might be leaking memory here,
-                                            // let's double-check if we can dispose the children.
-                                            di_composite_type
-                                                .replace_elements(MDNode::empty(self.context));
-                                            // Remove name.
-                                            di_composite_type
-                                                .replace_name(self.context, "")
-                                                .unwrap();
+                                            is_data_carrying_enum = true;
+                                            break;
                                         }
                                         _ => {}
                                     }
@@ -653,7 +643,9 @@ impl DISanitizer {
                                 _ => {}
                             }
                         }
-                        if !members.is_empty() {
+                        if is_data_carrying_enum {
+                            di_composite_type.replace_elements(MDNode::empty(self.context));
+                        } else if !members.is_empty() {
                             members.sort_by_cached_key(|di_type| di_type.offset_in_bits());
                             let sorted_elements =
                                 MDNode::with_elements(self.context, members.as_mut_slice());

--- a/tests/btf/assembly/data-carrying-enum.rs
+++ b/tests/btf/assembly/data-carrying-enum.rs
@@ -1,0 +1,43 @@
+// assembly-output: bpf-linker
+// compile-flags: --crate-type cdylib -C link-arg=--emit=obj -C debuginfo=2
+
+#![no_std]
+
+pub enum SimpleEnum {
+    First,
+    Second,
+    Third,
+}
+
+pub enum DataCarryingEnum {
+    First { a: u32, b: i32 },
+    Second(u32, i32),
+    Third(u32),
+}
+
+#[no_mangle]
+pub static A: SimpleEnum = SimpleEnum::First;
+#[no_mangle]
+pub static B: SimpleEnum = SimpleEnum::Second;
+#[no_mangle]
+pub static C: SimpleEnum = SimpleEnum::Third;
+
+#[no_mangle]
+pub static X: DataCarryingEnum = DataCarryingEnum::First { a: 54, b: -23 };
+#[no_mangle]
+pub static Y: DataCarryingEnum = DataCarryingEnum::Second(54, -23);
+#[no_mangle]
+pub static Z: DataCarryingEnum = DataCarryingEnum::Third(36);
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+// The data-carrying enum should be not included in BTF.
+
+// CHECK: ENUM 'SimpleEnum' encoding=UNSIGNED size=1 vlen=3
+// CHECK-NEXT: 'First' val=0
+// CHECK-NEXT: 'Second' val=1
+// CHECK-NEXT: 'Third' val=2
+// CHECK-NOT: ENUM 'DataCarryingEnum'


### PR DESCRIPTION
Data carrying enums are causing a crash of the BPF Assembly Printer pass. As a workaround, we were always replacing the elements of that enum metadata with an empty MDNode.

However, #142 broke this behavior by calling `replace_elements` on a wrong composite type - it was calling it on the inner one (data carrying field), instead of the outer one (enum). This change fixes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/151)
<!-- Reviewable:end -->
