### PR TITLE
Remove redundant `all-targets-init` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ name = "bpf-linker"
 rust-llvm = [
     "dep:aya-rustc-llvm-proxy",
     "llvm-sys/no-llvm-linking",
-    "llvm-sys/disable-alltargets-init",
 ]
 default = ["rust-llvm"]
 


### PR DESCRIPTION
This feature is always on since ff02db63ba94d7a44feeb894f863952e77e4dc41.
