### PR TITLE
chore: Use `tracing` instead of `log` and `simplelog`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,11 +111,13 @@ dependencies = [
  "gimli",
  "libc",
  "llvm-sys",
- "log",
  "regex",
  "rustc-build-sysroot",
- "simplelog",
  "thiserror",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "tracing-tree",
  "which",
 ]
 
@@ -234,10 +236,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.8"
+name = "crossbeam-channel"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "diff"
@@ -446,6 +466,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +490,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,19 +525,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -550,8 +613,17 @@ checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -562,8 +634,14 @@ checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.2",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -669,15 +747,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "simplelog"
-version = "0.12.1"
+name = "sharded-slab"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
- "log",
- "termcolor",
- "time",
+ "lazy_static",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "stable_deref_trait"
@@ -727,15 +809,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "tester"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,15 +842,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.29"
+name = "thread_local"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
- "num_threads",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -791,11 +874,97 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term 0.46.0",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-tree"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65139ecd2c3f6484c3b99bc01c77afe21e95473630747c7aca525e78b0666675"
+dependencies = [
+ "nu-ansi-term 0.49.0",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -815,6 +984,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wasi"
@@ -850,15 +1025,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ edition = "2021"
 [dependencies]
 # cli deps
 clap = { version = "4.4.7", features = ["derive"] }
-simplelog = { version = "0.12.1" }
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
+tracing-tree = "0.3"
 
 # lib deps
 ar = { version = "0.9.0" }
@@ -26,8 +28,8 @@ aya-rustc-llvm-proxy = { version = "0.9.0", optional = true }
 gimli = { version = "0.28.0" }
 libc = { version = "0.2.150" }
 llvm-sys = { version = "170.0.0" }
-log = { version = "0.4.20" }
 thiserror = { version = "1.0.50" }
+tracing = "0.1"
 
 [dev-dependencies]
 compiletest_rs = { version = "0.10.1" }

--- a/src/bin/bpf-linker.rs
+++ b/src/bin/bpf-linker.rs
@@ -3,22 +3,15 @@
 #[cfg(feature = "rust-llvm")]
 extern crate aya_rustc_llvm_proxy;
 
-use std::{
-    env,
-    fs::{self, OpenOptions},
-    os::fd::AsRawFd,
-    path::PathBuf,
-    str::FromStr,
-};
+use std::{env, fs, io, path::PathBuf, str::FromStr};
 
 use bpf_linker::{Cpu, Linker, LinkerOptions, OptLevel, OutputType};
 use clap::Parser;
-use libc::dup2;
-use log::info;
-use simplelog::{
-    ColorChoice, Config, LevelFilter, SimpleLogger, TermLogger, TerminalMode, WriteLogger,
-};
 use thiserror::Error;
+use tracing::{info, Level, Subscriber};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{fmt::MakeWriter, prelude::*, EnvFilter};
+use tracing_tree::HierarchicalLayer;
 
 #[derive(Debug, Error)]
 enum CliError {
@@ -65,6 +58,7 @@ impl FromStr for CliOutputType {
         }))
     }
 }
+
 #[derive(Debug, Parser)]
 struct CommandLine {
     /// LLVM target triple. When not provided, the target is inferred from the inputs
@@ -109,9 +103,10 @@ struct CommandLine {
     #[clap(long, value_name = "path")]
     log_file: Option<PathBuf>,
 
-    /// Set the log level. Can be one of `off`, `info`, `warn`, `debug`, `trace`.
+    /// Set the log level. If not specified, no logging is used. Can be one of
+    /// `error`, `warn`, `info`, `debug`, `trace`.
     #[clap(long, value_name = "level")]
-    log_level: Option<LevelFilter>,
+    log_level: Option<Level>,
 
     /// Try hard to unroll loops. Useful when targeting kernels that don't support loops
     #[clap(long)]
@@ -155,6 +150,18 @@ struct CommandLine {
     _debug: bool,
 }
 
+/// Returns a [`HierarchicalLayer`](tracing_tree::HierarchicalLayer) for the
+/// given `writer`.
+fn tracing_layer<W>(writer: W) -> HierarchicalLayer<W>
+where
+    W: for<'writer> MakeWriter<'writer> + 'static,
+{
+    const TRACING_IDENT: usize = 2;
+    HierarchicalLayer::new(TRACING_IDENT)
+        .with_indent_lines(true)
+        .with_writer(writer)
+}
+
 fn main() {
     let args = env::args().map(|arg| {
         if arg == "-flavor" {
@@ -191,51 +198,38 @@ fn main() {
         error("no input files", clap::error::ErrorKind::TooFewValues);
     }
 
-    let env_log_level = match env::var("RUST_LOG") {
-        Ok(s) if !s.is_empty() => match s.parse::<LevelFilter>() {
-            Ok(l) => Some(l),
-            Err(e) => error(
-                &format!("invalid RUST_LOG value: {e}"),
-                clap::error::ErrorKind::InvalidValue,
-            ),
-        },
-        _ => None,
-    };
-    let log_level = log_level.or(env_log_level).unwrap_or(LevelFilter::Warn);
-    if let Some(log_file) = log_file {
-        let log_file = match OpenOptions::new().create(true).append(true).open(log_file) {
-            Ok(f) => {
-                // Use dup2 to duplicate stderr fd to the log file fd
-                let result = unsafe { dup2(f.as_raw_fd(), std::io::stderr().as_raw_fd()) };
-
-                if result == -1 {
-                    error(
-                        &format!(
-                            "failed to duplicate stderr: {}",
-                            std::io::Error::last_os_error()
-                        ),
-                        clap::error::ErrorKind::Io,
-                    )
-                }
-                f
-            }
-            Err(e) => {
-                error(
-                    &format!("failed to open log file: {e:?}"),
-                    clap::error::ErrorKind::Io,
+    // Configure tracing.
+    if let Some(log_level) = log_level {
+        let subscriber_registry = tracing_subscriber::registry()
+            .with(EnvFilter::from_default_env().add_directive(log_level.into()));
+        let (subscriber, _guard): (
+            Box<dyn Subscriber + Send + Sync + 'static>,
+            Option<WorkerGuard>,
+        ) = match log_file {
+            Some(log_file) => {
+                let file_appender = tracing_appender::rolling::never(
+                    log_file.parent().unwrap_or_else(|| {
+                        error("invalid log_file", clap::error::ErrorKind::InvalidValue)
+                    }),
+                    log_file.file_name().unwrap_or_else(|| {
+                        error("invalid log_file", clap::error::ErrorKind::InvalidValue)
+                    }),
                 );
+                let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+                let subscriber = subscriber_registry
+                    .with(tracing_layer(io::stdout))
+                    .with(tracing_layer(non_blocking));
+
+                (Box::new(subscriber), Some(_guard))
+            }
+            None => {
+                let subscriber = subscriber_registry.with(tracing_layer(io::stderr));
+                (Box::new(subscriber), None)
             }
         };
-        WriteLogger::init(log_level, Config::default(), log_file).unwrap();
-    } else if TermLogger::init(
-        log_level,
-        Config::default(),
-        TerminalMode::Mixed,
-        ColorChoice::Auto,
-    )
-    .is_err()
-    {
-        SimpleLogger::init(log_level, Config::default()).unwrap();
+        if let Err(e) = tracing::subscriber::set_global_default(subscriber) {
+            error(&e.to_string(), clap::error::ErrorKind::Format);
+        }
     }
 
     info!(

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -22,8 +22,8 @@ use llvm_sys::{
     prelude::{LLVMContextRef, LLVMModuleRef},
     target_machine::{LLVMCodeGenFileType, LLVMDisposeTargetMachine, LLVMTargetMachineRef},
 };
-use log::{debug, error, info, warn};
 use thiserror::Error;
+use tracing::{debug, error, info, warn};
 
 use crate::llvm;
 

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -125,8 +125,7 @@ impl DISanitizer {
                                             };
 
                                             warn!(
-                                                "found data carrying enum {name} ({filename}:{line}), not emitting
-                                                the debug info for it"
+                                                "found data carrying enum {name} ({filename}:{line}), not emitting the debug info for it"
                                             );
 
                                             is_data_carrying_enum = true;

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -48,7 +48,7 @@ use llvm_sys::{
     },
     LLVMAttributeFunctionIndex, LLVMLinkage, LLVMVisibility,
 };
-use log::{debug, error};
+use tracing::{debug, error};
 
 use crate::OptLevel;
 


### PR DESCRIPTION
Structured logging from `tracing` meets our needs better, especially in the parts of bpf-linker which sanitize the debug info.

Fixes #177

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/179)
<!-- Reviewable:end -->
