### PR TITLE
readme: Recommend `debuginfo=2` instead of `debuginfo=1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To emit [BTF debug information](https://www.kernel.org/doc/html/next/bpf/btf.htm
 set the following rustflags:
 
 ```
--C debuginfo=1 -C link-arg=--btf
+-C debuginfo=2 -C link-arg=--btf
 ```
 
 These flags will work only for the eBPF targets (`bpfeb-unknown-none`,


### PR DESCRIPTION
Using `1` often emits insufficient amount of debug info. Emitting as much as possible with `2` is a safe bet, especially since the BTF pass strips anything unnecessary.