### PR TITLE
Install llvm-18 instead of llvm-18-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           echo -e deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ matrix.llvm }} main | sudo tee /etc/apt/sources.list.d/llvm.list
 
           sudo apt update
-          sudo apt -y install llvm-${{ matrix.llvm }}-dev
+          sudo apt -y install llvm-${{ matrix.llvm }}
           echo /usr/lib/llvm-${{ matrix.llvm }}/bin >> $GITHUB_PATH
 
       - name: Restore LLVM
@@ -152,14 +152,14 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
 
       - name: Check
-        run: cargo hack check --feature-powerset --features llvm-sys/force-dynamic
+        run: cargo hack check --feature-powerset
 
       - name: Build
-        run: cargo hack build --feature-powerset --features llvm-sys/force-dynamic
+        run: cargo hack build --feature-powerset
 
       - name: Test
         if: matrix.rust == 'nightly'
-        run: cargo hack test --feature-powerset --features llvm-sys/force-dynamic
+        run: cargo hack test --feature-powerset
 
       - uses: actions/checkout@v4
         if: matrix.rust == 'nightly'


### PR DESCRIPTION
It's not clear why we need -dev and this is currently failing in CI:
```
The following packages have unmet dependencies:
 libllvm18 : Breaks: llvm-18-dev (< 1:18.1.8~++20240730104741) but
1:18.1.8~++20240730092223+3b5b5c1ec4a3-1~exp1~20240730092238.143 is to
  be installed
E: Unable to correct problems, you have held broken packages.
Error: Process completed with exit code 100.
```
