### PR TITLE
chore: Update to LLVM 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,9 @@ jobs:
         rust:
           - stable
           - beta
-          # TODO: unpin nightly. There was a regression in
-          # https://github.com/rust-lang/rust/compare/1cec373f6...becebb315 that causes
-          # tests/btf/assembly/anon_struct_c.rs to fail to link.
-          - nightly-2024-04-16
+          - nightly
         llvm:
-          - 18
+          - 19
           - source
     name: rustc=${{ matrix.rust }} llvm=${{ matrix.llvm }}
     needs: llvm
@@ -121,7 +118,20 @@ jobs:
           echo -e deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ matrix.llvm }} main | sudo tee /etc/apt/sources.list.d/llvm.list
 
           sudo apt update
-          sudo apt -y install llvm-${{ matrix.llvm }}-dev
+          # TODO(vadorovsky): Remove the requirement of libpolly.
+          #
+          # Packages from apt.llvm.org are being built all at once, with one
+          # cmake build with superset of options, then different binaries and
+          # libraries are being included in different packages.
+          #
+          # That results in `llvm-config --libname --link-static` mentioning
+          # libpolly, even if it's not installed. The output of that command is
+          # being used in build.rs of llvm-sys, so building llvm-sys on such
+          # system is complaining about lack of libpolly.
+          #
+          # Hopefully that nightmare goes away once we switch to binstalls and
+          # ditch the system LLVM option.
+          sudo apt -y install llvm-${{ matrix.llvm }}-dev libpolly-${{ matrix.llvm }}-dev
           echo /usr/lib/llvm-${{ matrix.llvm }}/bin >> $GITHUB_PATH
 
       - name: Restore LLVM
@@ -152,14 +162,14 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
 
       - name: Check
-        run: cargo hack check --feature-powerset --features llvm-sys/force-dynamic
+        run: cargo hack check --feature-powerset
 
       - name: Build
-        run: cargo hack build --feature-powerset --features llvm-sys/force-dynamic
+        run: cargo hack build --feature-powerset
 
       - name: Test
         if: matrix.rust == 'nightly'
-        run: cargo hack test --feature-powerset --features llvm-sys/force-dynamic
+        run: cargo hack test --feature-powerset
 
       - uses: actions/checkout@v4
         if: matrix.rust == 'nightly'
@@ -170,7 +180,7 @@ jobs:
 
       - name: Install
         if: matrix.rust == 'nightly'
-        run: cargo install --path . --no-default-features --features llvm-sys/force-dynamic
+        run: cargo install --path . --no-default-features
 
       # TODO: Remove this and run the integration tests on the local machine when they pass on 5.15.
       - name: Download debian kernels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
           set -euxo pipefail
           mkdir -p test/.tmp/debian-kernels/arm64
           printf '%s\0' \
-            linux-image-6.1.0-15-cloud-arm64-unsigned_6.1.66-1_arm64.deb \
+            linux-image-6.1.0-16-cloud-arm64-unsigned_6.1.67-1_arm64.deb \
           | xargs -0 -t -P0 -I {} wget -nd -nv -P test/.tmp/debian-kernels/arm64 ftp://ftp.us.debian.org/debian/pool/main/l/linux/{}
 
       # TODO: Remove this and run the integration tests on the local machine when they pass on 5.15.
@@ -201,7 +201,7 @@ jobs:
           set -euxo pipefail
           mkdir -p test/.tmp/debian-kernels/amd64
           printf '%s\0' \
-            linux-image-6.1.0-15-cloud-amd64-unsigned_6.1.66-1_amd64.deb \
+            linux-image-6.1.0-16-cloud-amd64-unsigned_6.1.67-1_amd64.deb \
           | xargs -0 -t -P0 -I {} wget -nd -nv -P test/.tmp/debian-kernels/amd64 ftp://ftp.us.debian.org/debian/pool/main/l/linux/{}
 
       # TODO: Remove this and run the integration tests on the local machine when they pass on 5.15.

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -16,7 +16,7 @@ jobs:
       - id: ls-remote
         run: |
           set -euxo pipefail
-          value=$(git ls-remote https://github.com/aya-rs/llvm-project.git refs/heads/rustc/18.0-2024-02-13 | cut -f1)
+          value=$(git ls-remote https://github.com/aya-rs/llvm-project.git refs/heads/rustc/19.1-2024-07-30 | cut -f1)
           echo "sha=$value" >> "$GITHUB_OUTPUT"
 
       - id: cache-key

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "cargo_metadata",
  "libc",
  "libloading",
- "llvm-sys 191.0.0-rc1",
+ "llvm-sys",
  "once_cell",
  "prettyplease",
  "quote",
@@ -112,7 +112,7 @@ dependencies = [
  "compiletest_rs",
  "gimli",
  "libc",
- "llvm-sys 180.0.0",
+ "llvm-sys",
  "log",
  "regex",
  "rustc-build-sysroot",
@@ -444,20 +444,6 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
-name = "llvm-sys"
-version = "180.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778fa5fa02e32728e718f11eec147e6f134137399ab02fd2c13d32476337affa"
-dependencies = [
- "anyhow",
- "cc",
- "lazy_static",
- "libc",
- "regex-lite",
- "semver",
-]
 
 [[package]]
 name = "llvm-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ar = { version = "0.9.0" }
 aya-rustc-llvm-proxy = { version = "0.9.3", optional = true }
 gimli = { version = "0.31.0" }
 libc = { version = "0.2.155" }
-llvm-sys = { features = ["disable-alltargets-init"], version = "180.0.0-rc2" }
+llvm-sys = { features = ["disable-alltargets-init"], version = "191.0.0-rc1" }
 log = { version = "0.4.22" }
 thiserror = { version = "1.0.63" }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ files with embedded bitcode (.o), optionally stored inside ar archives (.a).
 
 ## Installation
 
-The linker requires LLVM 18. It can use the same LLVM used by the rust compiler,
+The linker requires LLVM 19. It can use the same LLVM used by the rust compiler,
 or it can use an external LLVM installation.
 
 If your target is `aarch64-unknown-linux-gnu` (i.e. Linux on Apple Silicon) you 
@@ -33,14 +33,14 @@ cargo install bpf-linker
 
 ### Using external LLVM
 
-On Debian based distributions you need to install the `llvm-18-dev`, `libclang-18-dev`
-and `libpolly-18-dev` packages. If your distro doesn't have them you can get them
+On Debian based distributions you need to install the `llvm-19-dev`, `libclang-19-dev`
+and `libpolly-19-dev` packages. If your distro doesn't have them you can get them
 from the official LLVM repo at https://apt.llvm.org.
 
 On rpm based distribution you need the `llvm-devel` and `clang-devel` packages.
 If your distro doesn't have them you can get them from Fedora Rawhide.
 
-Once you have installed LLVM 18 you can install the linker running:
+Once you have installed LLVM 19 you can install the linker running:
 
 ```sh
 cargo install bpf-linker --no-default-features


### PR DESCRIPTION
Latest Rust nightly switched to LLVM 19, so we need to update in order to support rustc-llvm-proxy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/214)
<!-- Reviewable:end -->
