### PR TITLE
 Move diagnostic handler to a separate struct

### DIFF
--- a/src/linker.rs
+++ b/src/linker.rs
@@ -229,7 +229,7 @@ pub struct Linker {
     context: LLVMContextRef,
     module: LLVMModuleRef,
     target_machine: LLVMTargetMachineRef,
-    has_errors: bool,
+    diagnostic_handler: DiagnosticHandler,
 }
 
 impl Linker {
@@ -240,7 +240,7 @@ impl Linker {
             context: ptr::null_mut(),
             module: ptr::null_mut(),
             target_machine: ptr::null_mut(),
-            has_errors: false,
+            diagnostic_handler: DiagnosticHandler::new(),
         }
     }
 
@@ -270,7 +270,7 @@ impl Linker {
     }
 
     pub fn has_errors(&self) -> bool {
-        self.has_errors
+        self.diagnostic_handler.has_errors
     }
 
     fn link_modules(&mut self) -> Result<(), LinkerError> {
@@ -537,8 +537,8 @@ impl Linker {
             self.context = LLVMContextCreate();
             LLVMContextSetDiagnosticHandler(
                 self.context,
-                Some(llvm::diagnostic_handler::<Self>),
-                self as *mut _ as _,
+                Some(llvm::diagnostic_handler::<DiagnosticHandler>),
+                &mut self.diagnostic_handler as *mut _ as _,
             );
             LLVMInstallFatalErrorHandler(Some(llvm::fatal_error));
             LLVMEnablePrettyStackTrace();
@@ -551,7 +551,39 @@ impl Linker {
     }
 }
 
-impl llvm::LLVMDiagnosticHandler for Linker {
+impl Drop for Linker {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.target_machine.is_null() {
+                LLVMDisposeTargetMachine(self.target_machine);
+            }
+            if !self.module.is_null() {
+                LLVMDisposeModule(self.module);
+            }
+            if !self.context.is_null() {
+                LLVMContextDispose(self.context);
+            }
+        }
+    }
+}
+
+pub struct DiagnosticHandler {
+    pub(crate) has_errors: bool,
+}
+
+impl Default for DiagnosticHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DiagnosticHandler {
+    pub fn new() -> Self {
+        Self { has_errors: false }
+    }
+}
+
+impl llvm::LLVMDiagnosticHandler for DiagnosticHandler {
     fn handle_diagnostic(&mut self, severity: llvm_sys::LLVMDiagnosticSeverity, message: &str) {
         // TODO(https://reviews.llvm.org/D155894): Remove this when LLVM no longer emits these
         // errors.
@@ -578,22 +610,6 @@ impl llvm::LLVMDiagnosticHandler for Linker {
             llvm_sys::LLVMDiagnosticSeverity::LLVMDSWarning => warn!("llvm: {}", message),
             llvm_sys::LLVMDiagnosticSeverity::LLVMDSRemark => debug!("remark: {}", message),
             llvm_sys::LLVMDiagnosticSeverity::LLVMDSNote => debug!("note: {}", message),
-        }
-    }
-}
-
-impl Drop for Linker {
-    fn drop(&mut self) {
-        unsafe {
-            if !self.target_machine.is_null() {
-                LLVMDisposeTargetMachine(self.target_machine);
-            }
-            if !self.module.is_null() {
-                LLVMDisposeModule(self.module);
-            }
-            if !self.context.is_null() {
-                LLVMContextDispose(self.context);
-            }
         }
     }
 }


### PR DESCRIPTION
Add the `DiagnosticHandler` struct which implements `LLVMDiagnosticHandler`, so only that struct and not the whole `Linker` is passed to `LLVMContextSetDiagnosticHandler`.

This is going to make writing a safe wrapper for `Context` easier.

---

Depends on #223

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/224)
<!-- Reviewable:end -->
