### PR TITLE
Add more safe wrappers

### DIFF
--- a/src/bin/bpf-linker.rs
+++ b/src/bin/bpf-linker.rs
@@ -9,7 +9,7 @@ use std::{
     str::FromStr,
 };
 
-use bpf_linker::{Cpu, Linker, LinkerOptions, OptLevel, OutputType};
+use bpf_linker::{llvm::types::ir::Context, Cpu, Linker, LinkerOptions, OptLevel, OutputType};
 use clap::{
     builder::{PathBufValueParser, TypedValueParser as _},
     error::ErrorKind,
@@ -281,24 +281,30 @@ fn main() -> anyhow::Result<()> {
         [.., CliOptLevel(optimize)] => optimize,
     };
 
-    let mut linker = Linker::new(LinkerOptions {
-        target,
-        cpu,
-        cpu_features,
-        inputs,
-        output,
-        output_type,
-        libs,
-        optimize,
-        export_symbols,
-        unroll_loops,
-        ignore_inline_never,
-        dump_module,
-        llvm_args,
-        disable_expand_memcpy_in_order,
-        disable_memory_builtins,
-        btf,
-    });
+    let mut context = Context::new();
+    let module = context.create_module(output.file_stem().unwrap().to_str().unwrap());
+    let mut linker = Linker::new(
+        LinkerOptions {
+            target,
+            cpu,
+            cpu_features,
+            inputs,
+            output,
+            output_type,
+            libs,
+            optimize,
+            export_symbols,
+            unroll_loops,
+            ignore_inline_never,
+            dump_module,
+            llvm_args,
+            disable_expand_memcpy_in_order,
+            disable_memory_builtins,
+            btf,
+        },
+        context,
+        module,
+    )?;
 
     linker.link()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,6 @@
 #![deny(unused_results)]
 
 mod linker;
-mod llvm;
+pub mod llvm;
 
 pub use linker::*;

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -229,7 +229,7 @@ pub struct Linker {
     context: LLVMContextRef,
     module: LLVMModuleRef,
     target_machine: LLVMTargetMachineRef,
-    has_errors: bool,
+    diagnostic_handler: DiagnosticHandler,
 }
 
 impl Linker {
@@ -240,7 +240,7 @@ impl Linker {
             context: ptr::null_mut(),
             module: ptr::null_mut(),
             target_machine: ptr::null_mut(),
-            has_errors: false,
+            diagnostic_handler: DiagnosticHandler::new(),
         }
     }
 
@@ -270,7 +270,7 @@ impl Linker {
     }
 
     pub fn has_errors(&self) -> bool {
-        self.has_errors
+        self.diagnostic_handler.has_errors
     }
 
     fn link_modules(&mut self) -> Result<(), LinkerError> {
@@ -537,8 +537,8 @@ impl Linker {
             self.context = LLVMContextCreate();
             LLVMContextSetDiagnosticHandler(
                 self.context,
-                Some(llvm::diagnostic_handler::<Self>),
-                self as *mut _ as _,
+                Some(llvm::diagnostic_handler::<DiagnosticHandler>),
+                &mut self.diagnostic_handler as *mut _ as _,
             );
             LLVMInstallFatalErrorHandler(Some(llvm::fatal_error));
             LLVMEnablePrettyStackTrace();
@@ -551,7 +551,33 @@ impl Linker {
     }
 }
 
-impl llvm::LLVMDiagnosticHandler for Linker {
+impl Drop for Linker {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.target_machine.is_null() {
+                LLVMDisposeTargetMachine(self.target_machine);
+            }
+            if !self.module.is_null() {
+                LLVMDisposeModule(self.module);
+            }
+            if !self.context.is_null() {
+                LLVMContextDispose(self.context);
+            }
+        }
+    }
+}
+
+pub struct DiagnosticHandler {
+    pub(crate) has_errors: bool,
+}
+
+impl DiagnosticHandler {
+    pub fn new() -> Self {
+        Self { has_errors: false }
+    }
+}
+
+impl llvm::LLVMDiagnosticHandler for DiagnosticHandler {
     fn handle_diagnostic(&mut self, severity: llvm_sys::LLVMDiagnosticSeverity, message: &str) {
         // TODO(https://reviews.llvm.org/D155894): Remove this when LLVM no longer emits these
         // errors.
@@ -578,22 +604,6 @@ impl llvm::LLVMDiagnosticHandler for Linker {
             llvm_sys::LLVMDiagnosticSeverity::LLVMDSWarning => warn!("llvm: {}", message),
             llvm_sys::LLVMDiagnosticSeverity::LLVMDSRemark => debug!("remark: {}", message),
             llvm_sys::LLVMDiagnosticSeverity::LLVMDSNote => debug!("note: {}", message),
-        }
-    }
-}
-
-impl Drop for Linker {
-    fn drop(&mut self) {
-        unsafe {
-            if !self.target_machine.is_null() {
-                LLVMDisposeTargetMachine(self.target_machine);
-            }
-            if !self.module.is_null() {
-                LLVMDisposeModule(self.module);
-            }
-            if !self.context.is_null() {
-                LLVMContextDispose(self.context);
-            }
         }
     }
 }

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -26,7 +26,6 @@ pub struct DISanitizer {
     module: LLVMModuleRef,
     builder: LLVMDIBuilderRef,
     visited_nodes: HashSet<u64>,
-    item_stack: Vec<Item>,
     replace_operands: HashMap<u64, LLVMMetadataRef>,
     skipped_types: Vec<String>,
 }
@@ -66,7 +65,6 @@ impl DISanitizer {
             module,
             builder: unsafe { LLVMCreateDIBuilder(module) },
             visited_nodes: HashSet::new(),
-            item_stack: Vec::new(),
             replace_operands: HashMap::new(),
             skipped_types: Vec::new(),
         }
@@ -249,8 +247,6 @@ impl DISanitizer {
             return;
         }
 
-        self.item_stack.push(item.clone());
-
         if let Value::MDNode(mdnode) = value.clone() {
             self.visit_mdnode(mdnode)
         }
@@ -285,8 +281,6 @@ impl DISanitizer {
                 }
             }
         }
-
-        let _ = self.item_stack.pop().unwrap();
     }
 
     pub fn run(mut self, exported_symbols: &HashSet<Cow<'static, str>>) {

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -10,11 +10,14 @@ use gimli::{DW_TAG_pointer_type, DW_TAG_structure_type, DW_TAG_variant_part};
 use llvm_sys::{core::*, debuginfo::*, prelude::*};
 use tracing::{span, trace, warn, Level};
 
-use super::types::{
-    di::DIType,
-    ir::{Function, MDNode, Metadata, Value},
+use crate::llvm::{
+    iter::*,
+    types::{
+        di::{DISubprogram, DIType},
+        ir::{Function, MDNode, Metadata, Value},
+        LLVMTypeWrapper,
+    },
 };
-use crate::llvm::{iter::*, types::di::DISubprogram};
 
 // KSYM_NAME_LEN from linux kernel intentionally set
 // to lower value found accross kernel versions to ensure
@@ -227,7 +230,7 @@ impl DISanitizer {
             // An operand with no value is valid and means that the operand is
             // not set
             (v, Item::Operand { .. }) if v.is_null() => return,
-            (v, _) if !v.is_null() => Value::new(v),
+            (v, _) if !v.is_null() => unsafe { Value::from_ptr(v) },
             // All other items should have values
             (_, item) => panic!("{item:?} has no value"),
         };
@@ -331,7 +334,7 @@ impl DISanitizer {
         for mut function in self
             .module
             .functions_iter()
-            .map(|value| unsafe { Function::from_value_ref(value) })
+            .map(|value| unsafe { Function::from_ptr(value) })
         {
             if export_symbols.contains(function.name()) {
                 continue;
@@ -370,7 +373,7 @@ impl DISanitizer {
                 // replace retained nodes manually below.
                 LLVMDIBuilderFinalizeSubprogram(self.builder, new_program);
 
-                DISubprogram::from_value_ref(LLVMMetadataAsValue(self.context, new_program))
+                DISubprogram::from_ptr(LLVMMetadataAsValue(self.context, new_program))
             };
 
             // Point the function to the new subprogram.
@@ -396,8 +399,8 @@ impl DISanitizer {
                 unsafe { LLVMMDNodeInContext2(self.context, core::ptr::null_mut(), 0) };
             subprogram.set_retained_nodes(empty_node);
 
-            let ret = replace.insert(subprogram.value_ref as u64, unsafe {
-                LLVMValueAsMetadata(new_program.value_ref)
+            let ret = replace.insert(subprogram.as_ptr() as u64, unsafe {
+                LLVMValueAsMetadata(new_program.as_ptr())
             });
             assert!(ret.is_none());
         }

--- a/src/llvm/iter.rs
+++ b/src/llvm/iter.rs
@@ -7,25 +7,52 @@ use llvm_sys::{
         LLVMGetLastGlobalAlias, LLVMGetLastInstruction, LLVMGetNextBasicBlock, LLVMGetNextFunction,
         LLVMGetNextGlobal, LLVMGetNextGlobalAlias, LLVMGetNextInstruction,
     },
-    prelude::{LLVMBasicBlockRef, LLVMModuleRef, LLVMValueRef},
+    prelude::{LLVMBasicBlockRef, LLVMValueRef},
 };
 
+use crate::llvm::types::ir::{BasicBlock, Function, Instruction, Module, Value};
+
 macro_rules! llvm_iterator {
-    ($trait_name:ident, $iterator_name:ident, $iterable:ty, $method_name:ident, $item_ty:ty, $first:expr, $last:expr, $next:expr $(,)?) => {
+    (
+        $trait_name:ident,
+        $iterator_name:ident,
+        $iterable:ident,
+        $method_name:ident,
+        $mut_method_name:ident,
+        $item_ptr_ty:ident,
+        $item_wrapper_ty:ident,
+        $first:expr,
+        $last:expr,
+        $next:expr $(,)?
+    ) => {
         pub trait $trait_name {
             fn $method_name(&self) -> $iterator_name;
+            fn $mut_method_name(&mut self) -> $iterator_name;
         }
 
         pub struct $iterator_name<'a> {
-            lifetime: PhantomData<&'a $iterable>,
-            next: $item_ty,
-            last: $item_ty,
+            lifetime: PhantomData<&'a $iterable<'a>>,
+            next: $item_ptr_ty,
+            last: $item_ptr_ty,
         }
 
-        impl $trait_name for $iterable {
+        impl<'ctx> $trait_name for $iterable<'ctx> {
             fn $method_name(&self) -> $iterator_name {
-                let first = unsafe { $first(*self) };
-                let last = unsafe { $last(*self) };
+                use $crate::llvm::LLVMTypeWrapper;
+                let first = unsafe { $first(self.as_ptr()) };
+                let last = unsafe { $last(self.as_ptr()) };
+                assert_eq!(first.is_null(), last.is_null());
+                $iterator_name {
+                    lifetime: PhantomData,
+                    next: first,
+                    last,
+                }
+            }
+
+            fn $mut_method_name(&mut self) -> $iterator_name {
+                use $crate::llvm::LLVMTypeWrapper;
+                let first = unsafe { $first(self.as_ptr()) };
+                let last = unsafe { $last(self.as_ptr()) };
                 assert_eq!(first.is_null(), last.is_null());
                 $iterator_name {
                     lifetime: PhantomData,
@@ -36,7 +63,7 @@ macro_rules! llvm_iterator {
         }
 
         impl<'a> Iterator for $iterator_name<'a> {
-            type Item = $item_ty;
+            type Item = $item_wrapper_ty<'a>;
 
             fn next(&mut self) -> Option<Self::Item> {
                 let Self {
@@ -51,6 +78,9 @@ macro_rules! llvm_iterator {
                 let item = *next;
                 *next = unsafe { $next(*next) };
                 assert_eq!(next.is_null(), last);
+                let item = unsafe {
+                    <$item_wrapper_ty as $crate::llvm::types::LLVMTypeWrapper>::from_ptr(item)
+                };
                 Some(item)
             }
         }
@@ -60,9 +90,11 @@ macro_rules! llvm_iterator {
 llvm_iterator! {
     IterModuleGlobals,
     GlobalsIter,
-    LLVMModuleRef,
+    Module,
     globals_iter,
+    globals_iter_mut,
     LLVMValueRef,
+    Value,
     LLVMGetFirstGlobal,
     LLVMGetLastGlobal,
     LLVMGetNextGlobal,
@@ -71,9 +103,11 @@ llvm_iterator! {
 llvm_iterator! {
     IterModuleGlobalAliases,
     GlobalAliasesIter,
-    LLVMModuleRef,
+    Module,
     global_aliases_iter,
+    global_aliases_iter_mut,
     LLVMValueRef,
+    Value,
     LLVMGetFirstGlobalAlias,
     LLVMGetLastGlobalAlias,
     LLVMGetNextGlobalAlias,
@@ -82,9 +116,11 @@ llvm_iterator! {
 llvm_iterator! {
     IterModuleFunctions,
     FunctionsIter,
-    LLVMModuleRef,
+    Module,
     functions_iter,
+    functions_iter_mut,
     LLVMValueRef,
+    Function,
     LLVMGetFirstFunction,
     LLVMGetLastFunction,
     LLVMGetNextFunction,
@@ -93,9 +129,11 @@ llvm_iterator! {
 llvm_iterator!(
     IterBasicBlocks,
     BasicBlockIter,
-    LLVMValueRef,
+    Function,
     basic_blocks_iter,
+    basic_blocks_iter_mut,
     LLVMBasicBlockRef,
+    BasicBlock,
     LLVMGetFirstBasicBlock,
     LLVMGetLastBasicBlock,
     LLVMGetNextBasicBlock
@@ -104,9 +142,11 @@ llvm_iterator!(
 llvm_iterator!(
     IterInstructions,
     InstructionsIter,
-    LLVMBasicBlockRef,
+    BasicBlock,
     instructions_iter,
+    instructions_iter_mut,
     LLVMValueRef,
+    Instruction,
     LLVMGetFirstInstruction,
     LLVMGetLastInstruction,
     LLVMGetNextInstruction

--- a/src/llvm/types/mod.rs
+++ b/src/llvm/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod di;
 pub mod ir;
+pub mod target;
 
 pub trait LLVMTypeWrapper {
     type Target: ?Sized;

--- a/src/llvm/types/mod.rs
+++ b/src/llvm/types/mod.rs
@@ -1,2 +1,9 @@
 pub mod di;
 pub mod ir;
+
+pub trait LLVMTypeWrapper {
+    type Target: ?Sized;
+
+    unsafe fn from_ptr(ptr: Self::Target) -> Self;
+    fn as_ptr(&self) -> Self::Target;
+}

--- a/src/llvm/types/target.rs
+++ b/src/llvm/types/target.rs
@@ -1,0 +1,97 @@
+use std::{
+    ffi::{CStr, CString},
+    ptr::{self, NonNull},
+};
+
+use llvm_sys::target_machine::{
+    LLVMCodeGenOptLevel, LLVMCodeModel, LLVMCreateTargetMachine, LLVMDisposeTargetMachine,
+    LLVMGetTargetFromTriple, LLVMRelocMode, LLVMTargetMachineRef, LLVMTargetRef,
+};
+
+use crate::llvm::{types::LLVMTypeWrapper, LLVMError, Message};
+
+pub struct Target {
+    target_ref: LLVMTargetRef,
+}
+
+impl LLVMTypeWrapper for Target {
+    type Target = LLVMTargetRef;
+
+    unsafe fn from_ptr(target_ref: Self::Target) -> Self {
+        Self { target_ref }
+    }
+
+    fn as_ptr(&self) -> Self::Target {
+        self.target_ref
+    }
+}
+
+impl Target {
+    pub fn from_triple(triple: &CStr) -> Result<Self, LLVMError> {
+        let mut target_ref = ptr::null_mut();
+        let (ret, message) = unsafe {
+            Message::with(|message| {
+                LLVMGetTargetFromTriple(triple.as_ptr(), &mut target_ref, message)
+            })
+        };
+        if ret == 0 {
+            Ok(Self { target_ref })
+        } else {
+            Err(LLVMError::FailedToResolveTarget(
+                triple.to_str().unwrap().to_string(),
+                message.as_c_str().unwrap().to_str().unwrap().to_string(),
+            ))
+        }
+    }
+
+    pub fn create_target_machine(
+        &self,
+        triple: &str,
+        cpu: &str,
+        features: &str,
+    ) -> Option<TargetMachine> {
+        let triple = CString::new(triple).unwrap();
+        let cpu = CString::new(cpu).unwrap();
+        let features = CString::new(features).unwrap();
+        let tm = unsafe {
+            LLVMCreateTargetMachine(
+                self.as_ptr(),
+                triple.as_ptr(),
+                cpu.as_ptr(),
+                features.as_ptr(),
+                LLVMCodeGenOptLevel::LLVMCodeGenLevelAggressive,
+                LLVMRelocMode::LLVMRelocDefault,
+                LLVMCodeModel::LLVMCodeModelDefault,
+            )
+        };
+        NonNull::new(tm).map(|tm| TargetMachine::from_target_machine_ref(tm.as_ptr()))
+    }
+}
+
+pub struct TargetMachine {
+    target_machine_ref: LLVMTargetMachineRef,
+}
+
+impl LLVMTypeWrapper for TargetMachine {
+    type Target = LLVMTargetMachineRef;
+
+    unsafe fn from_ptr(target_machine_ref: Self::Target) -> Self {
+        Self { target_machine_ref }
+    }
+
+    fn as_ptr(&self) -> Self::Target {
+        self.target_machine_ref
+    }
+}
+
+impl Drop for TargetMachine {
+    fn drop(&mut self) {
+        unsafe { LLVMDisposeTargetMachine(self.target_machine_ref) }
+    }
+}
+
+impl TargetMachine {
+    pub fn from_target_machine_ref(target_machine_ref: LLVMTargetMachineRef) -> Self {
+        Self { target_machine_ref }
+    }
+}


### PR DESCRIPTION
Add more safe wrappers

- Add safe wrappers for:
  - `Context`
  - `Module`
  - `DIBuilder`
- Modify the `iter` module and its macros to operate on wrappers.

---

Depends on #224

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/225)
<!-- Reviewable:end -->
