### PR TITLE
ci: Update kernel images, run local integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,29 +182,34 @@ jobs:
         if: matrix.rust == 'nightly'
         run: cargo install --path . --no-default-features
 
-      # TODO: Remove this and run the integration tests on the local machine when they pass on 5.15.
       - name: Download debian kernels
         if: matrix.rust == 'nightly' && runner.arch == 'ARM64'
         working-directory: aya
         run: |
           set -euxo pipefail
           mkdir -p test/.tmp/debian-kernels/arm64
+          # NB: a 4.19 kernel image for arm64 was not available.
+          # TODO: enable tests on kernels before 6.0.
+          # linux-image-5.10.0-23-cloud-arm64-unsigned_5.10.179-3_arm64.deb \
           printf '%s\0' \
-            linux-image-6.1.0-16-cloud-arm64-unsigned_6.1.67-1_arm64.deb \
+            linux-image-6.1.0-22-cloud-arm64-unsigned_6.1.94-1_arm64.deb \
+            linux-image-6.10.9-cloud-arm64-unsigned_6.10.9-1_arm64.deb \
           | xargs -0 -t -P0 -I {} wget -nd -nv -P test/.tmp/debian-kernels/arm64 ftp://ftp.us.debian.org/debian/pool/main/l/linux/{}
 
-      # TODO: Remove this and run the integration tests on the local machine when they pass on 5.15.
       - name: Download debian kernels
-        if: matrix.rust == 'nightly' && runner.arch == 'X64'
+        if: runner.arch == 'X64'
         working-directory: aya
         run: |
           set -euxo pipefail
           mkdir -p test/.tmp/debian-kernels/amd64
+          # TODO: enable tests on kernels before 6.0.
+          # linux-image-4.19.0-21-cloud-amd64-unsigned_4.19.249-2_amd64.deb \
+          # linux-image-5.10.0-23-cloud-amd64-unsigned_5.10.179-3_amd64.deb \
           printf '%s\0' \
-            linux-image-6.1.0-16-cloud-amd64-unsigned_6.1.67-1_amd64.deb \
+            linux-image-6.1.0-22-cloud-amd64-unsigned_6.1.94-1_amd64.deb \
+            linux-image-6.10.9-cloud-amd64-unsigned_6.10.9-1_amd64.deb \
           | xargs -0 -t -P0 -I {} wget -nd -nv -P test/.tmp/debian-kernels/amd64 ftp://ftp.us.debian.org/debian/pool/main/l/linux/{}
 
-      # TODO: Remove this and run the integration tests on the local machine when they pass on 5.15.
       - name: Extract debian kernels
         if: matrix.rust == 'nightly'
         working-directory: aya
@@ -213,7 +218,12 @@ jobs:
           find test/.tmp -name '*.deb' -print0 | xargs -t -0 -I {} \
             sh -c "dpkg --fsys-tarfile {} | tar -C test/.tmp --wildcards --extract '*vmlinuz*' --file -"
 
-      - name: Run aya integration tests
+      - name: Run aya integration tests (local)
+        if: runner.os == 'Linux'
+        working-directory: aya
+        run: cargo xtask integration-test local
+
+      - name: Run aya integration tests (virtualized)
         if: matrix.rust == 'nightly'
         working-directory: aya
         run: |


### PR DESCRIPTION
- Update kernel images for virtualized tests.
- Add local integration tests, runners have recent enough kernel to be able to run them now.
- Remove the comment which propsoes removal of virtualized tests. They are actually convenient for testing different kernel versions and are going to be useful for cross-compilation, which is proposed in #215.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/229)
<!-- Reviewable:end -->
