### PR TITLE
chore: Update from rc release of LLVM and llvm-sys to the stable one

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -16,7 +16,7 @@ jobs:
       - id: ls-remote
         run: |
           set -euxo pipefail
-          value=$(git ls-remote https://github.com/aya-rs/llvm-project.git refs/heads/rustc/19.1-2024-07-30 | cut -f1)
+          value=$(git ls-remote https://github.com/aya-rs/llvm-project.git refs/heads/rustc/19.1-2024-09-17 | cut -f1)
           echo "sha=$value" >> "$GITHUB_OUTPUT"
 
       - id: cache-key

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,9 +447,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "llvm-sys"
-version = "191.0.0-rc1"
+version = "191.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc981f56df5430a462d0f7676913fe9e8e4c8cc4df02e3157a6e3d808f7ae443"
+checksum = "893cddf1adf0354b93411e413553dd4daf5c43195d73f1acfa1e394bdd371456"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ar = { version = "0.9.0" }
 aya-rustc-llvm-proxy = { version = "0.9.3", optional = true }
 gimli = { version = "0.31.0" }
 libc = { version = "0.2.158" }
-llvm-sys = { features = ["disable-alltargets-init"], version = "191.0.0-rc1" }
+llvm-sys = { features = ["disable-alltargets-init"], version = "191.0.0" }
 log = { version = "0.4.22" }
 thiserror = { version = "1.0.64" }
 tracing = "0.1"


### PR DESCRIPTION
- Update `llvm-sys` from `191.0.0-rc1` to `191.0.0`.
- Update LLVM to the `rustc/19.1-2024-09-17` branch, which is based on the stable LLVM 19.1.0 release.
  - The mentioned branch in our LLVM fork contains a backport of llvm/llvm-project#107802, which is needed for our work on BTF relocations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/231)
<!-- Reviewable:end -->
