### PR TITLE
test: Use btfdump instead of bpftool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,10 @@ jobs:
       - name: Build (default features, no system LLVM)
         run: cargo build
 
+      - name: Install btfdump
+        if: matrix.rust == 'nightly'
+        run: cargo install btfdump
+
       - name: Install prerequisites
         if: matrix.rust == 'nightly'
         # ubuntu-22.04 comes with clang 13-15[0]; support for signed and 64bit

--- a/tests/btf/assembly/anon_rust.rs
+++ b/tests/btf/assembly/anon_rust.rs
@@ -29,6 +29,6 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-// CHECK: [16] STRUCT '(anon)' size=8 vlen=2
-// CHECK-NEXT: 'ayy' type_id=17 bits_offset=0
-// CHECK-NEXT: 'lmao' type_id=17 bits_offset=32
+// CHECK: <STRUCT> '<anon>' sz:8 n:2
+// CHECK-NEXT: 'ayy' off:0 --> [17]
+// CHECK-NEXT: 'lmao' off:32 --> [17]

--- a/tests/btf/assembly/anon_struct_c.rs
+++ b/tests/btf/assembly/anon_struct_c.rs
@@ -37,5 +37,5 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-// CHECK: [9] TYPEDEF 'incognito' type_id=10
-// CHECK: [10] STRUCT '(anon)' size=4 vlen=1
+// CHECK: <TYPEDEF> 'incognito' --> [10]
+// CHECK: <STRUCT> '<anon>' sz:4 n:1

--- a/tests/btf/assembly/basic.rs
+++ b/tests/btf/assembly/basic.rs
@@ -14,5 +14,5 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-// We check the BTF dump out of bpftool
-// CHECK: FUNC 'connect' type_id=1 linkage=global
+// We check the BTF dump out of btfdump
+// CHECK: <FUNC> 'connect' --> global

--- a/tests/btf/assembly/data-carrying-enum.rs
+++ b/tests/btf/assembly/data-carrying-enum.rs
@@ -36,8 +36,8 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 
 // The data-carrying enum should be not included in BTF.
 
-// CHECK: ENUM 'SimpleEnum'{{.*}} size=1 vlen=3
-// CHECK-NEXT: 'First' val=0
-// CHECK-NEXT: 'Second' val=1
-// CHECK-NEXT: 'Third' val=2
-// CHECK-NOT: ENUM 'DataCarryingEnum'
+// CHECK: <ENUM> 'SimpleEnum' sz:1 n:3
+// CHECK-NEXT: First = 0
+// CHECK-NEXT: Second = 1
+// CHECK-NEXT: Third = 2
+// CHECK-NOT: <ENUM> 'DataCarryingEnum'

--- a/tests/btf/assembly/exported-symbols.rs
+++ b/tests/btf/assembly/exported-symbols.rs
@@ -35,16 +35,16 @@ fn inline_function_2(v: u8) -> u8 {
 }
 
 // #[no_mangle] functions keep linkage=global
-// CHECK: FUNC 'local_no_mangle' type_id={{[0-9]+}} linkage=global
+// CHECK: <FUNC> 'local_no_mangle' --> global [{{[0-9]+}}
 
 // check that parameter names are preserved
-// CHECK: FUNC_PROTO
+// CHECK: <FUNC_PROTO>
 // CHECK-NEXT: _arg1
 // CHECK-NEXT: _arg2
 
 // public functions get static linkage
-// CHECK: FUNC '{{.*}}local_public{{.*}}' type_id={{[0-9]+}} linkage=static
-// CHECK: FUNC '{{.*}}dep_public_symbol{{.*}}' type_id={{[0-9]+}} linkage=static
+// CHECK: <FUNC> '{{.*}}local_public{{.*}}' --> static
+// CHECK: <FUNC> '{{.*}}dep_public_symbol{{.*}}' --> static
 
 // #[no_mangle] is honored for dep functions
-// CHECK: FUNC 'dep_no_mangle' type_id={{[0-9]+}} linkage=global
+// CHECK: <FUNC> 'dep_no_mangle' --> global

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -96,17 +96,12 @@ where
 fn btf_dump(src: &Path, dst: &Path) {
     let dst = std::fs::File::create(dst)
         .unwrap_or_else(|err| panic!("could not open btf dump file '{}': {err}", dst.display()));
-    let mut bpftool = Command::new("bpftool");
-    bpftool
-        .arg("btf")
-        .arg("dump")
-        .arg("file")
-        .arg(src)
-        .stdout(dst);
-    let status = bpftool
+    let mut btf = Command::new("btf");
+    btf.arg("dump").arg(src).stdout(dst);
+    let status = btf
         .status()
-        .unwrap_or_else(|err| panic!("could not run {bpftool:?}: {err}",));
-    assert_eq!(status.code(), Some(0), "{bpftool:?} failed");
+        .unwrap_or_else(|err| panic!("could not run {btf:?}: {err}",));
+    assert_eq!(status.code(), Some(0), "{btf:?} failed");
 }
 
 #[test]


### PR DESCRIPTION
The former can be installed and used on macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/237)
<!-- Reviewable:end -->
