### PR TITLE
cargo clippy --fix

### DIFF
--- a/src/llvm/types/di.rs
+++ b/src/llvm/types/di.rs
@@ -45,7 +45,7 @@ pub struct DIFile<'ctx> {
     _marker: PhantomData<&'ctx ()>,
 }
 
-impl<'ctx> DIFile<'ctx> {
+impl DIFile<'_> {
     /// Constructs a new [`DIFile`] from the given `metadata`.
     ///
     /// # Safety
@@ -114,7 +114,7 @@ pub struct DIType<'ctx> {
     _marker: PhantomData<&'ctx ()>,
 }
 
-impl<'ctx> DIType<'ctx> {
+impl DIType<'_> {
     /// Constructs a new [`DIType`] from the given `value`.
     ///
     /// # Safety
@@ -165,7 +165,7 @@ pub struct DIDerivedType<'ctx> {
     _marker: PhantomData<&'ctx ()>,
 }
 
-impl<'ctx> DIDerivedType<'ctx> {
+impl DIDerivedType<'_> {
     /// Constructs a new [`DIDerivedType`] from the given `value`.
     ///
     /// # Safety
@@ -226,7 +226,7 @@ pub struct DICompositeType<'ctx> {
     _marker: PhantomData<&'ctx ()>,
 }
 
-impl<'ctx> DICompositeType<'ctx> {
+impl DICompositeType<'_> {
     /// Constructs a new [`DICompositeType`] from the given `value`.
     ///
     /// # Safety
@@ -328,7 +328,7 @@ pub struct DISubprogram<'ctx> {
     _marker: PhantomData<&'ctx ()>,
 }
 
-impl<'ctx> DISubprogram<'ctx> {
+impl DISubprogram<'_> {
     /// Constructs a new [`DISubprogram`] from the given `value`.
     ///
     /// # Safety

--- a/src/llvm/types/ir.rs
+++ b/src/llvm/types/ir.rs
@@ -45,7 +45,7 @@ pub enum Value<'ctx> {
     Other(LLVMValueRef),
 }
 
-impl<'ctx> std::fmt::Debug for Value<'ctx> {
+impl std::fmt::Debug for Value<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value_to_string = |value| {
             Message {
@@ -74,7 +74,7 @@ impl<'ctx> std::fmt::Debug for Value<'ctx> {
     }
 }
 
-impl<'ctx> Value<'ctx> {
+impl Value<'_> {
     pub fn new(value: LLVMValueRef) -> Self {
         if unsafe { !LLVMIsAMDNode(value).is_null() } {
             let mdnode = unsafe { MDNode::from_value_ref(value) };
@@ -115,7 +115,7 @@ pub enum Metadata<'ctx> {
     Other(#[allow(dead_code)] LLVMValueRef),
 }
 
-impl<'ctx> Metadata<'ctx> {
+impl Metadata<'_> {
     /// Constructs a new [`Metadata`] from the given `value`.
     ///
     /// # Safety
@@ -193,7 +193,7 @@ pub struct MDNode<'ctx> {
     _marker: PhantomData<&'ctx ()>,
 }
 
-impl<'ctx> MDNode<'ctx> {
+impl MDNode<'_> {
     /// Constructs a new [`MDNode`] from the given `metadata`.
     ///
     /// # Safety


### PR DESCRIPTION
`needless_lifetimes` seems to be on by default now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/245)
<!-- Reviewable:end -->
