### PR TITLE
Move off of OsStrExt.

### DIFF
--- a/src/linker.rs
+++ b/src/linker.rs
@@ -5,7 +5,6 @@ use std::{
     fs::File,
     io,
     io::{Read, Seek},
-    os::unix::ffi::OsStrExt as _,
     path::{Path, PathBuf},
     ptr, str,
     str::FromStr,
@@ -255,14 +254,14 @@ impl Linker {
         if let Some(path) = &self.options.dump_module {
             // dump IR before optimization
             let path = path.join("pre-opt.ll");
-            let path = CString::new(path.as_os_str().as_bytes()).unwrap();
+            let path = CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
             self.write_ir(&path)?;
         };
         self.optimize()?;
         if let Some(path) = &self.options.dump_module {
             // dump IR before optimization
             let path = path.join("post-opt.ll");
-            let path = CString::new(path.as_os_str().as_bytes()).unwrap();
+            let path = CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
             self.write_ir(&path)?;
         };
         self.codegen()?;


### PR DESCRIPTION
In stable as of 1.74.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/253)
<!-- Reviewable:end -->
