### PR TITLE
fix: c_void enum in BTF

### DIFF
--- a/src/llvm/types/di.rs
+++ b/src/llvm/types/di.rs
@@ -7,13 +7,17 @@ use std::{
 
 use gimli::DwTag;
 use llvm_sys::{
-    core::{LLVMGetNumOperands, LLVMGetOperand, LLVMReplaceMDNodeOperandWith, LLVMValueAsMetadata},
-    debuginfo::{
-        LLVMDIFileGetFilename, LLVMDIFlags, LLVMDIScopeGetFile, LLVMDISubprogramGetLine,
-        LLVMDITypeGetFlags, LLVMDITypeGetLine, LLVMDITypeGetName, LLVMDITypeGetOffsetInBits,
-        LLVMGetDINodeTag,
+    core::{
+        LLVMGetNumOperands, LLVMGetOperand, LLVMMetadataAsValue, LLVMReplaceMDNodeOperandWith,
+        LLVMValueAsMetadata,
     },
-    prelude::{LLVMContextRef, LLVMMetadataRef, LLVMValueRef},
+    debuginfo::{
+        LLVMDIBuilderCreateBasicType, LLVMDIBuilderGetOrCreateTypeArray, LLVMDIFileGetFilename,
+        LLVMDIFlags, LLVMDIScopeGetFile, LLVMDISubprogramGetLine, LLVMDITypeGetFlags,
+        LLVMDITypeGetLine, LLVMDITypeGetName, LLVMDITypeGetOffsetInBits, LLVMDITypeGetSizeInBits,
+        LLVMDWARFTypeEncoding, LLVMGetDINodeTag,
+    },
+    prelude::{LLVMContextRef, LLVMDIBuilderRef, LLVMMetadataRef, LLVMValueRef},
 };
 
 use crate::llvm::{
@@ -221,7 +225,7 @@ enum DICompositeTypeOperand {
 /// Composite type is a kind of type that can include other types, such as
 /// structures, enums, unions, etc.
 pub struct DICompositeType<'ctx> {
-    metadata_ref: LLVMMetadataRef,
+    pub(crate) metadata_ref: LLVMMetadataRef,
     value_ref: LLVMValueRef,
     _marker: PhantomData<&'ctx ()>,
 }
@@ -307,6 +311,11 @@ impl DICompositeType<'_> {
     /// Returns a DWARF tag of the given composite type.
     pub fn tag(&self) -> DwTag {
         unsafe { di_node_tag(self.metadata_ref) }
+    }
+
+    /// Returns the size in bits of the composite type.
+    pub fn size_in_bits(&self) -> u64 {
+        unsafe { LLVMDITypeGetSizeInBits(LLVMValueAsMetadata(self.value_ref)) }
     }
 }
 
@@ -428,5 +437,141 @@ impl DISubprogram<'_> {
                 nodes,
             )
         };
+    }
+}
+
+/// Represents the operands for a [`DICompileUnit`]. The enum values correspond
+/// to the operand indices within metadata nodes.
+#[repr(u32)]
+enum DICompileUnitOperand {
+    EnumTypes = 4,
+}
+
+/// Represents the debug information for a compile unit in LLVM IR.
+#[derive(Clone)]
+pub struct DICompileUnit<'ctx> {
+    value_ref: LLVMValueRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+impl<'ctx> DICompileUnit<'ctx> {
+    /// Constructs a new [`DICompileUnit`] from the given `value_ref`.
+    ///
+    /// # Safety
+    ///
+    /// This method assumes that the provided `value_ref` corresponds to a valid
+    /// instance of [LLVM `DICompileUnit`](https://llvm.org/doxygen/classllvm_1_1DICompileUnit.html).
+    /// It's the caller's responsibility to ensure this invariant, as this
+    /// method doesn't perform any valiation checks.
+    pub(crate) unsafe fn from_value_ref(value_ref: LLVMValueRef) -> Self {
+        Self {
+            value_ref,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn enum_types(&self) -> impl Iterator<Item = DICompositeType> {
+        let llvm_enum_types =
+            unsafe { LLVMGetOperand(self.value_ref, DICompileUnitOperand::EnumTypes as u32) };
+
+        let llvm_enum_types_len = if llvm_enum_types.is_null() {
+            0
+        } else {
+            unsafe { LLVMGetNumOperands(llvm_enum_types) }
+        };
+
+        (0..llvm_enum_types_len).map(move |i| unsafe {
+            let enum_type = LLVMGetOperand(llvm_enum_types, i as u32);
+            DICompositeType::from_value_ref(enum_type)
+        })
+    }
+
+    pub fn replace_enum_types<I>(&mut self, builder: LLVMDIBuilderRef, rep: I)
+    where
+        I: IntoIterator<Item = DICompositeType<'ctx>>,
+    {
+        let mut rep: Vec<_> = rep.into_iter().map(|dct| dct.metadata_ref).collect();
+
+        unsafe {
+            let enum_array =
+                LLVMDIBuilderGetOrCreateTypeArray(builder, rep.as_mut_ptr(), rep.len());
+            LLVMReplaceMDNodeOperandWith(
+                self.value_ref,
+                DICompileUnitOperand::EnumTypes as u32,
+                enum_array,
+            );
+        }
+    }
+}
+
+/// Represents [`DIBasicType`] kinds.
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+pub enum DIBasicTypeKind {
+    I8,
+}
+
+impl DIBasicTypeKind {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::I8 => "i8",
+        }
+    }
+
+    fn size_in_bits(&self) -> u64 {
+        match self {
+            Self::I8 => 8,
+        }
+    }
+
+    // DWARF encoding https://llvm.org/docs/LangRef.html#dibasictype
+    fn dwarf_type_encoding(&self) -> LLVMDWARFTypeEncoding {
+        match self {
+            // DW_ATE_signed
+            Self::I8 => gimli::DW_ATE_signed.0.into(),
+        }
+    }
+}
+
+/// Represents the debug information for a basic type in LLVM IR.
+pub struct DIBasicType<'ctx> {
+    pub(crate) value_ref: LLVMValueRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+impl DIBasicType<'_> {
+    /// Constructs a new [`DIBasicType`] from the given `value_ref`.
+    ///
+    /// # Safety
+    ///
+    /// This method assumes that the provided `value_ref` corresponds to a valid
+    /// instance of [LLVM `DIBasicType`](https://llvm.org/doxygen/classllvm_1_1DIBasicType.html).
+    /// It's the caller's responsibility to ensure this invariant, as this
+    /// method doesn't perform any valiation checks.
+    pub(crate) unsafe fn from_value_ref(value_ref: LLVMValueRef) -> Self {
+        Self {
+            value_ref,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Creates a new [`DIBasicType`] of `kind` given a `context` and a `builder`.
+    pub fn llvm_create(
+        ctx: LLVMContextRef,
+        builder: LLVMDIBuilderRef,
+        kind: DIBasicTypeKind,
+    ) -> Self {
+        let name = kind.name();
+        let metadata_ref = unsafe {
+            LLVMDIBuilderCreateBasicType(
+                builder,
+                name.as_ptr() as *const _,
+                name.len(),
+                kind.size_in_bits(),
+                kind.dwarf_type_encoding(),
+                0,
+            )
+        };
+
+        unsafe { Self::from_value_ref(LLVMMetadataAsValue(ctx, metadata_ref)) }
     }
 }

--- a/src/llvm/types/ir.rs
+++ b/src/llvm/types/ir.rs
@@ -22,7 +22,7 @@ use llvm_sys::{
 use crate::llvm::{
     iter::IterBasicBlocks as _,
     symbol_name,
-    types::di::{DICompositeType, DIDerivedType, DISubprogram, DIType},
+    types::di::{DICompileUnit, DICompositeType, DIDerivedType, DISubprogram, DIType},
     Message,
 };
 
@@ -112,6 +112,7 @@ pub enum Metadata<'ctx> {
     DICompositeType(DICompositeType<'ctx>),
     DIDerivedType(DIDerivedType<'ctx>),
     DISubprogram(DISubprogram<'ctx>),
+    DICompileUnit(#[allow(dead_code)] DICompileUnit<'ctx>),
     Other(#[allow(dead_code)] LLVMValueRef),
 }
 
@@ -140,6 +141,10 @@ impl Metadata<'_> {
                 let di_subprogram = unsafe { DISubprogram::from_value_ref(value) };
                 Metadata::DISubprogram(di_subprogram)
             }
+            LLVMMetadataKind::LLVMDICompileUnitMetadataKind => {
+                let di_compile_unit = unsafe { DICompileUnit::from_value_ref(value) };
+                Metadata::DICompileUnit(di_compile_unit)
+            }
             LLVMMetadataKind::LLVMDIGlobalVariableMetadataKind
             | LLVMMetadataKind::LLVMDICommonBlockMetadataKind
             | LLVMMetadataKind::LLVMMDStringMetadataKind
@@ -156,7 +161,6 @@ impl Metadata<'_> {
             | LLVMMetadataKind::LLVMDIBasicTypeMetadataKind
             | LLVMMetadataKind::LLVMDISubroutineTypeMetadataKind
             | LLVMMetadataKind::LLVMDIFileMetadataKind
-            | LLVMMetadataKind::LLVMDICompileUnitMetadataKind
             | LLVMMetadataKind::LLVMDILexicalBlockMetadataKind
             | LLVMMetadataKind::LLVMDILexicalBlockFileMetadataKind
             | LLVMMetadataKind::LLVMDINamespaceMetadataKind

--- a/tests/btf/assembly/c_void_enum.rs
+++ b/tests/btf/assembly/c_void_enum.rs
@@ -1,0 +1,19 @@
+// assembly-output: bpf-linker
+// no-prefer-dynamic
+// compile-flags: --crate-type bin -C link-arg=--emit=obj -C link-arg=--btf -C debuginfo=2
+
+#![no_std]
+#![no_main]
+
+use core::ffi::c_void;
+
+#[no_mangle]
+static mut FOO: *mut c_void = core::ptr::null_mut();
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+// We check the BTF dump out of btfdump
+// CHECK-NOT: <ENUM> 'c_void'


### PR DESCRIPTION
This PR fixes an issue with kernels < 5.4 failing to load BTF because of the [`c_void` enum](https://doc.rust-lang.org/std/ffi/enum.c_void.html).

When used in BPF code, the Rust `c_void` type (actually an enum) generates the following BTF:

```
#17: <ENUM> 'c_void' sz:1 n:2
  #00 __variant1 = 0
  #01 __variant2 = 1
```

It appears that kernels < 5.4 do not allow BTF enums with a size of 1 byte.

The fix consists of replacing the `c_void` enum MDNode with `i8` DI BasicType information.

To achieve this, a small refactoring of `DISanitizer::visit_mdnode` was necessary. The old `visit_mdnode` had only one `MDNode` argument, which would have required an additional argument to pass the `Item::Operand` to fix the MDNode. This was not optimal because both the `Operand` and the `MDNode` carry the same `LLVMValueRef`, which I found confusing (two arguments with the same information). The refactoring aims to make things cleaner and less confusing.

Another issue arose when using LLVM compiled with debug assertions. A casting assertion failed at [this line](https://github.com/llvm/llvm-project/blob/3e59710604e84d563962f259fef8b8a18c23f04e/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp#L1218):

```cpp
1218    for (auto *Ty : CUNode->getEnumTypes())
1219      CU.getOrCreateTypeDIE(cast<DIType>(Ty));
1220
```

The exact assertion failing downstream is `llvm::cast_if_present<llvm::DICompositeType, llvm::MDOperand> (Val=...)`. By inspecting `Val` (with gdb), we observe the following:

1. Its `MetadataKind` is `0xc` -> DIDerivedType
   ```
   print ((llvm::Metadata*) Val).SubclassID
   $16 = 0xc
   ```

2. This DIDerivedType is actually a pointer to the `DIBaseType` we replaced the `c_void` enum with:
   ```
   print ((llvm::DIDerivedType*) Val).DWARFAddressSpace
   $17 = std::optional = {
     [contained value] = 0x5
   }
   ```

   Note: `0x5` is the LLVMDWARFTypeEncoding we use in the `i8` DIBasicType to replace the `c_void` enum. I have confirmed this value corresponds to the LLVMDWARFTypeEncoding value.

I was unable to fully understand why and how this replacement happens. I speculate it is a side effect of replacing the `c_void` DICompositeType using `LLVMReplaceMDNodeOperandWith`. One observation is that it tends to happen when we replace the `c_void` enum use in an [MDTuple](https://llvm.org/doxygen/classllvm_1_1MDTuple.html).

However, the fact remains that the replaced `c_void` enums no longer need to exist in the DICompileUnit, as we have replaced any use of it. The proposed solution is to delete it completely using the `DISanitizer::fix_di_compile_units` function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/260)
<!-- Reviewable:end -->
