### PR TITLE
Appease `invalid_null_arguments`

### DIFF
--- a/tests/assembly/auxiliary/dep-exports.rs
+++ b/tests/assembly/auxiliary/dep-exports.rs
@@ -4,7 +4,7 @@
 
 pub fn dep_public_symbol() -> u8 {
     // read_volatile stops LTO inlining the function in the calling crate
-    unsafe { core::ptr::read_volatile(0 as *const u8) }
+    unsafe { core::ptr::read_volatile(core::ptr::dangling()) }
 }
 
 #[no_mangle]

--- a/tests/btf/assembly/auxiliary/dep-exports.rs
+++ b/tests/btf/assembly/auxiliary/dep-exports.rs
@@ -5,7 +5,7 @@
 #[inline(never)]
 pub fn dep_public_symbol() -> u8 {
     // read_volatile stops LTO inlining the function in the calling crate
-    unsafe { core::ptr::read_volatile(0 as *const u8) }
+    unsafe { core::ptr::read_volatile(core::ptr::dangling()) }
 }
 
 #[no_mangle]


### PR DESCRIPTION
This was promoted from a clippy lint in nightly.

Link: https://github.com/rust-lang/rust/pull/119220

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/265)
<!-- Reviewable:end -->
