### PR TITLE
chore: Fix rustc nightly warnings

### DIFF
--- a/src/llvm/iter.rs
+++ b/src/llvm/iter.rs
@@ -13,7 +13,7 @@ use llvm_sys::{
 macro_rules! llvm_iterator {
     ($trait_name:ident, $iterator_name:ident, $iterable:ty, $method_name:ident, $item_ty:ty, $first:expr, $last:expr, $next:expr $(,)?) => {
         pub trait $trait_name {
-            fn $method_name(&self) -> $iterator_name;
+            fn $method_name(&self) -> $iterator_name<'_>;
         }
 
         pub struct $iterator_name<'a> {
@@ -23,7 +23,7 @@ macro_rules! llvm_iterator {
         }
 
         impl $trait_name for $iterable {
-            fn $method_name(&self) -> $iterator_name {
+            fn $method_name(&self) -> $iterator_name<'_> {
                 let first = unsafe { $first(*self) };
                 let last = unsafe { $last(*self) };
                 assert_eq!(first.is_null(), last.is_null());

--- a/src/llvm/types/di.rs
+++ b/src/llvm/types/di.rs
@@ -184,7 +184,7 @@ impl DIDerivedType<'_> {
     }
 
     /// Returns the base type of this derived type.
-    pub fn base_type(&self) -> Metadata {
+    pub fn base_type(&self) -> Metadata<'_> {
         unsafe {
             let value = LLVMGetOperand(self.value_ref, DIDerivedTypeOperand::BaseType as u32);
             Metadata::from_value_ref(value)
@@ -246,7 +246,7 @@ impl DICompositeType<'_> {
 
     /// Returns an iterator over elements (struct fields, enum variants, etc.)
     /// of the composite type.
-    pub fn elements(&self) -> impl Iterator<Item = Metadata> {
+    pub fn elements(&self) -> impl Iterator<Item = Metadata<'_>> {
         let elements =
             unsafe { LLVMGetOperand(self.value_ref, DICompositeTypeOperand::Elements as u32) };
         let operands = NonNull::new(elements)
@@ -263,7 +263,7 @@ impl DICompositeType<'_> {
     }
 
     /// Returns the file that the composite type belongs to.
-    pub fn file(&self) -> DIFile {
+    pub fn file(&self) -> DIFile<'_> {
         unsafe {
             let metadata = LLVMDIScopeGetFile(self.metadata_ref);
             DIFile::from_metadata_ref(metadata)


### PR DESCRIPTION
Fix the `mismatched_lifetime_syntaxes` warnings, like:

```
warning: lifetime flowing from input to output with different syntax can be confusing
  --> src/llvm/iter.rs:26:29
   |
26 |               fn $method_name(&self) -> $iterator_name {
   |                               ^^^^^     -------------- the lifetime gets resolved as `'_`
   |                               |
   |                               this lifetime flows to the output
```

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/283)
<!-- Reviewable:end -->
