### PR TITLE
chore: Update to LLVM 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           - beta
           - nightly
         llvm:
-          - 20
+          - 21
           - source
     name: rustc=${{ matrix.rust }} llvm=${{ matrix.llvm }}
     needs: llvm

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -16,7 +16,7 @@ jobs:
       - id: ls-remote
         run: |
           set -euxo pipefail
-          value=$(git ls-remote https://github.com/aya-rs/llvm-project.git refs/heads/rustc/20.1-2025-02-13 | cut -f1)
+          value=$(git ls-remote https://github.com/aya-rs/llvm-project.git refs/heads/rustc/21.1-2025-08-01 | cut -f1)
           echo "sha=$value" >> "$GITHUB_OUTPUT"
 
       - id: cache-key

--- a/src/llvm/types/di.rs
+++ b/src/llvm/types/di.rs
@@ -150,8 +150,8 @@ impl<'ctx> From<DIDerivedType<'ctx>> for DIType<'ctx> {
 #[repr(u32)]
 enum DIDerivedTypeOperand {
     /// [`DIType`] representing a base type of the given derived type.
-    /// [Reference in LLVM code](https://github.com/llvm/llvm-project/blob/llvmorg-17.0.3/llvm/include/llvm/IR/DebugInfoMetadata.h#L1032).
-    BaseType = 3,
+    /// [Reference in LLVM code](https://github.com/llvm/llvm-project/blob/llvmorg-21.1.0-rc3/llvm/include/llvm/IR/DebugInfoMetadata.h#L1386).
+    BaseType = 5,
 }
 
 /// Represents the debug information for a derived type in LLVM IR.
@@ -212,8 +212,8 @@ impl DIDerivedType<'_> {
 #[repr(u32)]
 enum DICompositeTypeOperand {
     /// Elements of the composite type.
-    /// [Reference in LLVM code](https://github.com/llvm/llvm-project/blob/llvmorg-17.0.3/llvm/include/llvm/IR/DebugInfoMetadata.h#L1230).
-    Elements = 4,
+    /// [Reference in LLVM code](https://github.com/llvm/llvm-project/blob/llvmorg-21.1.0-rc3/llvm/include/llvm/IR/DebugInfoMetadata.h#L1813).
+    Elements = 6,
 }
 
 /// Represents the debug info for a composite type in LLVM IR.

--- a/tests/assembly/di_generics.rs
+++ b/tests/assembly/di_generics.rs
@@ -63,6 +63,6 @@ pub fn my_function<T: Add<Output = T> + Copy>(x: T, y: T) -> T {
         .add(y)
 }
 
-// CHECK: name: "Foo_3C_u32_3E_"
-// CHECK: name: "Bar_3C_di_generics_3A__3A_Foo_3C_u32_3E__3E_"
-// CHECK: name: "my_function_3C_u32_3E_"
+// CHECK-DAG: name: "Foo_3C_u32_3E_"
+// CHECK-DAG: name: "Bar_3C_di_generics_3A__3A_Foo_3C_u32_3E__3E_"
+// CHECK-DAG: name: "my_function_3C_u32_3E_"

--- a/tests/assembly/ignore-inline-never.rs
+++ b/tests/assembly/ignore-inline-never.rs
@@ -21,6 +21,6 @@ fn actually_inlined(a: u64) -> u64 {
 pub extern "C" fn fun(a: u64) -> u64 {
     // CHECK-LABEL: fun:
     actually_inlined(a)
-    // CHECK: r{{[0-9]}} = r{{[0-9]}}
-    // CHECK-NEXT: r{{[0-9]}} += 42
+    // CHECK-DAG: r{{[0-9]}} = r{{[0-9]}}
+    // CHECK-DAG: r{{[0-9]}} += 42
 }

--- a/tests/btf/assembly/exported-symbols.rs
+++ b/tests/btf/assembly/exported-symbols.rs
@@ -35,7 +35,7 @@ fn inline_function_2(v: u8) -> u8 {
 }
 
 // #[no_mangle] functions keep linkage=global
-// CHECK: <FUNC> 'local_no_mangle' --> global [{{[0-9]+}}
+// CHECK-DAG: <FUNC> 'local_no_mangle' --> global [{{[0-9]+}}
 
 // check that parameter names are preserved
 // CHECK: <FUNC_PROTO>
@@ -43,8 +43,8 @@ fn inline_function_2(v: u8) -> u8 {
 // CHECK-NEXT: _arg2
 
 // public functions get static linkage
-// CHECK: <FUNC> '{{.*}}local_public{{.*}}' --> static
-// CHECK: <FUNC> '{{.*}}dep_public_symbol{{.*}}' --> static
+// CHECK-DAG: <FUNC> '{{.*}}local_public{{.*}}' --> static
+// CHECK-DAG: <FUNC> '{{.*}}dep_public_symbol{{.*}}' --> static
 
 // #[no_mangle] is honored for dep functions
-// CHECK: <FUNC> 'dep_no_mangle' --> global
+// CHECK-DAG: <FUNC> 'dep_no_mangle' --> global


### PR DESCRIPTION
Latest Rust nightly switched to LLVM 21, so we need to update in order
to support rustc-llvm-proxy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/289)
<!-- Reviewable:end -->
