### PR TITLE
Support old Rust and LLVM versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           components: clippy, rust-src
 
       - name: Run clippy
-        run: cargo clippy --features llvm-sys/no-llvm-linking --all-targets --workspace -- --deny warnings
+        run: cargo clippy --features llvm-21,llvm-sys-21/no-llvm-linking --all-targets --workspace -- --deny warnings
 
   lint-nightly:
     runs-on: ubuntu-latest
@@ -53,13 +53,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust:
-          - stable
-          - beta
-          - nightly
-        llvm:
-          - 21
-          - source
+        include:
+          - rust: 1.86.0
+            llvm: 19
+            llvm-from: apt
+            exclude-features: default,llvm-20,llvm-21,rust-llvm-20,rust-llvm-21
+          - rust: 1.89.0
+            llvm: 20
+            llvm-from: apt
+            exclude-features: default,llvm-19,llvm-21,rust-llvm-19,rust-llvm-21
+          - rust: beta
+            llvm: 20
+            llvm-from: apt
+            exclude-features: default,llvm-19,llvm-21,rust-llvm-19,rust-llvm-21
+          - rust: nightly
+            llvm: 21
+            llvm-from: apt
+            exclude-features: llvm-19,llvm-20,rust-llvm-19,rust-llvm-20
+          - rust: nightly
+            llvm: 21
+            llvm-from: source
+            exclude-features: llvm-19,llvm-20,rust-llvm-19,rust-llvm-20
     name: rustc=${{ matrix.rust }} llvm=${{ matrix.llvm }}
     needs: llvm
 
@@ -70,13 +84,6 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust ${{ matrix.rust }}
-        if: matrix.rust != 'nightly'
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-
-      - name: Install Rust ${{ matrix.rust }}
-        if: matrix.rust == 'nightly'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -91,11 +98,9 @@ jobs:
         run: cargo build
 
       - name: Install btfdump
-        if: matrix.rust == 'nightly'
         run: cargo install btfdump
 
       - name: Install prerequisites
-        if: matrix.rust == 'nightly'
         # ubuntu-22.04 comes with clang 13-15[0]; support for signed and 64bit
         # enum values was added in clang 15[1] which isn't in `$PATH`.
         #
@@ -111,7 +116,7 @@ jobs:
           echo /usr/lib/llvm-15/bin >> $GITHUB_PATH
 
       - name: Install LLVM
-        if: matrix.llvm != 'source'
+        if: matrix.llvm-from == 'apt'
         run: |
           set -euxo pipefail
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
@@ -135,7 +140,7 @@ jobs:
           echo /usr/lib/llvm-${{ matrix.llvm }}/bin >> $GITHUB_PATH
 
       - name: Restore LLVM
-        if: matrix.llvm == 'source'
+        if: matrix.llvm-from == 'source'
         uses: actions/cache/restore@v4
         with:
           path: llvm-install
@@ -143,7 +148,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Add LLVM to PATH && LD_LIBRARY_PATH
-        if: matrix.llvm == 'source'
+        if: matrix.llvm-from == 'source'
         run: |
           set -euxo pipefail
           echo "${{ github.workspace }}/llvm-install/bin" >> $GITHUB_PATH
@@ -162,19 +167,32 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
 
       - name: Check
-        run: cargo hack check --feature-powerset
+        run: |
+          cargo hack check --feature-powerset \
+            --exclude-features ${{ matrix.exclude-features }} \
+            --features llvm-${{ matrix.llvm }}
 
       - name: Build
-        run: cargo hack build --feature-powerset
+        run: |
+          cargo hack build --feature-powerset \
+            --exclude-features ${{ matrix.exclude-features }} \
+            --features llvm-${{ matrix.llvm }}
 
       # Toolchains provided by rustup include standard library artifacts
       # only for Tier 1 targets, which do not include BPF targets.
       # The default workaround is to use the `rustc-build-sysroot` feature,
       # which builds a custom sysroot with the required BPF standard library
       # before running compiler tests.
+      #
+      # `RUSTC_BOOTSTRAP` is needed to make rustc-build-sysroot work on stable
+      # Rust.
       - name: Test (sysroot built on demand)
-        if: matrix.rust == 'nightly'
-        run: cargo hack test --feature-powerset --include-features rustc-build-sysroot
+        env:
+          RUSTC_BOOTSTRAP: 1
+        run: |
+          cargo hack test --feature-powerset \
+            --exclude-features ${{ matrix.exclude-features }} \
+            --features llvm-${{ matrix.llvm }},rustc-build-sysroot
 
       # To make things easier for package maintainers, the step of building
       # a custom sysroot can be skipped by omitting the `rustc-build-sysroot`
@@ -182,11 +200,17 @@ jobs:
       # is expected to already contain the prebuilt standard library.
       # Test this configuration by prebuilding the BPF standard library
       # manually.
+      #
+      # `RUSTC_BOOTSTRAP` is needed to make `xtask build-std` work on stable
+      # Rust.
       - name: Test (prebuilt BPF standard library)
-        if: matrix.rust == 'nightly'
+        env:
+          RUSTC_BOOTSTRAP: 1
         run: |
           cargo xtask build-std
-          cargo hack test --feature-powerset --exclude-features rustc-build-sysroot
+          cargo hack test --feature-powerset \
+            --exclude-features ${{ matrix.exclude-features }},rustc-build-sysroot \
+            --features llvm-${{ matrix.llvm }}
 
       - uses: actions/checkout@v5
         if: matrix.rust == 'nightly'
@@ -197,7 +221,7 @@ jobs:
 
       - name: Install
         if: matrix.rust == 'nightly'
-        run: cargo install --path . --no-default-features
+        run: cargo install --path . --no-default-features --features llvm-${{ matrix.llvm }}
 
       - name: Run aya integration tests
         if: matrix.rust == 'nightly'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
  "cargo_metadata",
  "libc",
  "libloading",
- "llvm-sys",
+ "llvm-sys 201.0.1",
  "prettyplease",
  "quote",
  "rustversion",
@@ -107,7 +107,9 @@ dependencies = [
  "compiletest_rs",
  "gimli",
  "libc",
- "llvm-sys",
+ "llvm-sys 191.0.0",
+ "llvm-sys 201.0.1",
+ "llvm-sys 211.0.0-rc1",
  "log",
  "regex",
  "rustc-build-sysroot",
@@ -454,9 +456,37 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "llvm-sys"
+version = "191.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893cddf1adf0354b93411e413553dd4daf5c43195d73f1acfa1e394bdd371456"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
+
+[[package]]
+name = "llvm-sys"
 version = "201.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb947e8b79254ca10d496d0798a9ba1287dcf68e50a92b016fec1cc45bef447"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
+
+[[package]]
+name = "llvm-sys"
+version = "211.0.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be054f99773257c9a3d5ae7d1c8d7e3c437c78794cc5cebcfb004dceec312ce6"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,9 @@ ar = { version = "0.9.0" }
 aya-rustc-llvm-proxy = { version = "0.9.4", optional = true }
 gimli = { version = "0.32.0" }
 libc = { version = "0.2.174" }
-llvm-sys = { features = ["disable-alltargets-init"], version = "201.0.0-rc1" }
+llvm-sys-19 = { package = "llvm-sys", features = ["disable-alltargets-init"], version = "191.0.0", optional = true }
+llvm-sys-20 = { package = "llvm-sys", features = ["disable-alltargets-init"], version = "201.0.1", optional = true }
+llvm-sys-21 = { package = "llvm-sys", features = ["disable-alltargets-init"], version = "211.0.0-rc1", optional = true }
 log = { version = "0.4.27" }
 thiserror = { version = "2.0.12" }
 tracing = "0.1"
@@ -43,12 +45,27 @@ which = { version = "8.0.0", default-features = false, features = ["real-sys", "
 name = "bpf-linker"
 
 [features]
-rust-llvm = [
+llvm-19 = ["dep:llvm-sys-19"]
+llvm-20 = ["dep:llvm-sys-20"]
+llvm-21 = ["dep:llvm-sys-21"]
+rust-llvm-19 = [
     "dep:aya-rustc-llvm-proxy",
-    "llvm-sys/no-llvm-linking",
+    "llvm-19",
+    "llvm-sys-19/no-llvm-linking",
+]
+rust-llvm-20 = [
+    "dep:aya-rustc-llvm-proxy",
+    "llvm-20",
+    "llvm-sys-20/no-llvm-linking",
+]
+rust-llvm-21 = [
+    "dep:aya-rustc-llvm-proxy",
+    "llvm-21",
+    "llvm-sys-21/no-llvm-linking",
 ]
 default = [
-    "rust-llvm",
+    "llvm-21",
+    "rust-llvm-21",
     "rustc-build-sysroot",
 ]
 rustc-build-sysroot = []

--- a/src/bin/bpf-linker.rs
+++ b/src/bin/bpf-linker.rs
@@ -1,6 +1,10 @@
 #![deny(clippy::all)]
 
-#[cfg(feature = "rust-llvm")]
+#[cfg(any(
+    feature = "rust-llvm-19",
+    feature = "rust-llvm-20",
+    feature = "rust-llvm-21"
+))]
 extern crate aya_rustc_llvm_proxy;
 
 use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,48 @@
 #![deny(clippy::all)]
 #![deny(unused_results)]
 
+// The following macros are adapted from from https://github.com/TheDan64/inkwell,
+// licensed under Apache-2.0.
+// Original source: https://github.com/TheDan64/inkwell/blob/0b0a2c0b2eb5e458767093c2ab8c56cbd05ec4c9/src/lib.rs#L85-L112
+
+macro_rules! assert_unique_features {
+    () => {};
+    ($first:tt $(,$rest:tt)*) => {
+        $(
+            #[cfg(all(feature = $first, feature = $rest))]
+            compile_error!(concat!("features \"", $first, "\" and \"", $rest, "\" cannot be used together"));
+        )*
+        assert_unique_features!($($rest),*);
+    }
+}
+
+macro_rules! assert_used_features {
+    ($($all:tt),*) => {
+        #[cfg(not(any($(feature = $all),*)))]
+        compile_error!(concat!("One of the LLVM feature flags must be provided: ", $($all, " "),*));
+    }
+}
+
+macro_rules! assert_unique_used_features {
+    ($($all:tt),*) => {
+        assert_unique_features!($($all),*);
+        assert_used_features!($($all),*);
+    }
+}
+
+assert_unique_used_features! {
+    "llvm-19",
+    "llvm-20",
+    "llvm-21"
+}
+
+#[cfg(feature = "llvm-19")]
+pub extern crate llvm_sys_19 as llvm_sys;
+#[cfg(feature = "llvm-20")]
+pub extern crate llvm_sys_20 as llvm_sys;
+#[cfg(feature = "llvm-21")]
+pub extern crate llvm_sys_21 as llvm_sys;
+
 mod linker;
 mod llvm;
 

--- a/src/llvm/types/di.rs
+++ b/src/llvm/types/di.rs
@@ -150,7 +150,14 @@ impl<'ctx> From<DIDerivedType<'ctx>> for DIType<'ctx> {
 #[repr(u32)]
 enum DIDerivedTypeOperand {
     /// [`DIType`] representing a base type of the given derived type.
-    /// [Reference in LLVM code](https://github.com/llvm/llvm-project/blob/llvmorg-21.1.0-rc3/llvm/include/llvm/IR/DebugInfoMetadata.h#L1386).
+    /// Reference in [LLVM 19-20][llvm-19] and [LLVM 21][llvm-21].
+    ///
+    /// [llvm-19]: https://github.com/llvm/llvm-project/blob/llvmorg-19.1.7/llvm/include/llvm/IR/DebugInfoMetadata.h#L1084
+    /// [llvm-21]: https://github.com/llvm/llvm-project/blob/llvmorg-21.1.0-rc3/llvm/include/llvm/IR/DebugInfoMetadata.h#L1386
+    ///
+    #[cfg(any(feature = "llvm-19", feature = "llvm-20"))]
+    BaseType = 3,
+    #[cfg(feature = "llvm-21")]
     BaseType = 5,
 }
 
@@ -211,8 +218,14 @@ impl DIDerivedType<'_> {
 /// correspond to the operand indices within metadata nodes.
 #[repr(u32)]
 enum DICompositeTypeOperand {
-    /// Elements of the composite type.
-    /// [Reference in LLVM code](https://github.com/llvm/llvm-project/blob/llvmorg-21.1.0-rc3/llvm/include/llvm/IR/DebugInfoMetadata.h#L1813).
+    /// Elements of the composite type. Reference in [LLVM 19-20][llvm-19] and
+    /// [LLVM 21][llvm-21].
+    ///
+    /// [llvm-19]: https://github.com/llvm/llvm-project/blob/llvmorg-19.1.7/llvm/include/llvm/IR/DebugInfoMetadata.h#L1299
+    /// [llvm-21]: https://github.com/llvm/llvm-project/blob/llvmorg-21.1.0-rc3/llvm/include/llvm/IR/DebugInfoMetadata.h#L1813
+    #[cfg(any(feature = "llvm-19", feature = "llvm-20"))]
+    Elements = 4,
+    #[cfg(feature = "llvm-21")]
     Elements = 6,
 }
 

--- a/src/llvm/types/ir.rs
+++ b/src/llvm/types/ir.rs
@@ -173,6 +173,9 @@ impl Metadata<'_> {
             | LLVMMetadataKind::LLVMDIGenericSubrangeMetadataKind
             | LLVMMetadataKind::LLVMDIArgListMetadataKind
             | LLVMMetadataKind::LLVMDIAssignIDMetadataKind => Metadata::Other(value),
+            #[cfg(feature = "llvm-21")]
+            LLVMMetadataKind::LLVMDISubrangeTypeMetadataKind
+            | LLVMMetadataKind::LLVMDIFixedPointTypeMetadataKind => Metadata::Other(value),
         }
     }
 }


### PR DESCRIPTION
Support LLVM versions down to 19 and Rust down to 1.86.0. This is going to make it easier for operating system distributions to package software using Aya.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/291)
<!-- Reviewable:end -->
