### PR TITLE
Prevent LLVM from inserting ksyms symbols

### DIFF
--- a/src/linker.rs
+++ b/src/linker.rs
@@ -529,6 +529,7 @@ impl Linker {
         if !self.options.disable_expand_memcpy_in_order {
             args.push("--bpf-expand-memcpy-in-order".into());
         }
+        args.push("--bpf-disable-trap-unreachable".into());
         args.extend(self.options.llvm_args.iter().map(Into::into));
         info!("LLVM command line: {:?}", args);
         unsafe {


### PR DESCRIPTION
Recent versions of LLVM [insert calls to `__bpf_trap`, which adds a `.ksyms` section](https://github.com/llvm/llvm-project/commit/ab391beb11f733b526b86f9df23734a34657d876). This is [not currently supported by aya](https://github.com/aya-rs/aya/issues/1245) and inevitably causes complex programs to fail to load.

This PR adds the command line switch which disables this behavior, but is only supported by very recent versions of LLVM. I'm not entirely sure how to check that the LLVM version used supports this, so I've marked this as draft.

Additionally, this behaviour is probably _desired_ once `.ksyms` is supported in aya, so this should be reverted when this happens.