### PR TITLE
chore: Update rustc-build-sysroot to 0.5.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,9 +697,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-build-sysroot"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb13874a0e55baf4ac3d49d38206aecb31a55b75d6c4d04fd850b53942c8cc8"
+checksum = "3b881c015c729b43105bbd3702a9bdecee28fafaa21126d1d62e454ec011a4b7"
 dependencies = [
  "anyhow",
  "rustc_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ members = ["xtask"]
 anyhow = { version = "1.0.99", default-features = false }
 clap = { version = "4.5.45", features = ["derive"] }
 # dev deps
-rustc-build-sysroot = { version = "0.5.9", default-features = false }
+rustc-build-sysroot = { version = "0.5.11", default-features = false }
 
 [profile.release]
 debug = true


### PR DESCRIPTION
It includes RalfJung/rustc-build-sysroot@8f34419eec2f which fixes our CI regression.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/296)
<!-- Reviewable:end -->
