### PR TITLE
Bump Beta to LLVM 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,9 @@ jobs:
             llvm-from: apt
             exclude-features: default,llvm-19,llvm-21,rust-llvm-19,rust-llvm-21
           - rust: beta
-            llvm: 20
+            llvm: 21
             llvm-from: apt
-            exclude-features: default,llvm-19,llvm-21,rust-llvm-19,rust-llvm-21
+            exclude-features: default,llvm-19,llvm-20,rust-llvm-19,rust-llvm-20
           - rust: nightly
             llvm: 21
             llvm-from: apt


### PR DESCRIPTION
Seems 1.90.0 just hit beta.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/304)
<!-- Reviewable:end -->
