### PR TITLE
ci: Remove unwanted software to free space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
       RUST_BACKTRACE: full
 
     steps:
+      - uses: jlumbroso/free-disk-space@main
+        with:          
+          # This option would remove LLVM/clang.
+          large-packages: false
+
       - uses: actions/checkout@v5
 
       - name: Install Rust ${{ matrix.rust }}


### PR DESCRIPTION
We are hitting errors because of no space left. Given that runners come with a lot of unnecessary software installed, use an action for removing it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/314)
<!-- Reviewable:end -->
