### PR TITLE
feat: add support for LLVM IR files in the linker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +114,7 @@ version = "0.9.15"
 dependencies = [
  "anyhow",
  "ar",
+ "assert_matches",
  "aya-rustc-llvm-proxy",
  "clap",
  "compiletest_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ object = { version = "0.38.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
+assert_matches = { version = "1.5.0", default-features = false }
 compiletest_rs = { version = "0.11.0" }
 regex = { version = "1.11.1", default-features = false }
 rustc-build-sysroot = { workspace = true }

--- a/src/bin/bpf-linker.rs
+++ b/src/bin/bpf-linker.rs
@@ -8,8 +8,6 @@ use std::{
     str::FromStr,
 };
 
-#[cfg(any(feature = "rust-llvm-20", feature = "rust-llvm-21"))]
-use aya_rustc_llvm_proxy as _;
 use bpf_linker::{Cpu, Linker, LinkerInput, LinkerOptions, OptLevel, OutputType};
 use clap::{
     Parser,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 
 #![expect(unused_crate_dependencies, reason = "used in bin")]
 
+#[cfg(any(feature = "rust-llvm-20", feature = "rust-llvm-21"))]
+use aya_rustc_llvm_proxy as _;
+
 macro_rules! assert_unique_features {
     () => {};
     ($first:tt $(,$rest:tt)*) => {

--- a/src/llvm/types/memory_buffer.rs
+++ b/src/llvm/types/memory_buffer.rs
@@ -5,6 +5,7 @@ use llvm_sys::{
     prelude::LLVMMemoryBufferRef,
 };
 
+#[derive(Debug)]
 pub(crate) struct MemoryBuffer {
     memory_buffer: LLVMMemoryBufferRef,
 }


### PR DESCRIPTION
# Context

Recently I was testing generating IR with different languages and using LLVM to generate the bitcode, then using [sbpf-linker](https://github.com/blueshift-gg/sbpf-linker) to generate a .so file

# Problem

In the process we need this extra step to generate the .bc with LLVM. I started a thread on X about adding .ll files as parameters for the sbpf-linker and then and alessandro [mention ](https://x.com/alessandrod/status/1983399388560183399?s=20)the possibility of adding it for bpf-linker and here we are!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/323)
<!-- Reviewable:end -->
