### PR TITLE
.github: grant permissions to upload bins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
   release:
     types: [published]
 
-permissions: {}
+permissions:
+  # This is used by the upload-rust-binary-action to upload the binary to the release.
+  contents: write
 
 jobs:
   upload-bins:


### PR DESCRIPTION
This was broken in 48abae88d8ed6b01653f012cdf110515db94aac0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/341)
<!-- Reviewable:end -->
