### PR TITLE
Sanitize union names in BTF metadata

### DIFF
--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -7,7 +7,7 @@ use std::{
     ptr,
 };
 
-use gimli::{DW_TAG_pointer_type, DW_TAG_structure_type, DW_TAG_variant_part};
+use gimli::{DW_TAG_pointer_type, DW_TAG_structure_type, DW_TAG_union_type, DW_TAG_variant_part};
 use llvm_sys::{core::*, debuginfo::*, prelude::*};
 use tracing::{Level, span, trace, warn};
 
@@ -77,7 +77,7 @@ impl<'ctx> DISanitizer<'ctx> {
                 #[expect(clippy::single_match)]
                 #[expect(non_upper_case_globals)]
                 match di_composite_type.tag() {
-                    DW_TAG_structure_type => {
+                    DW_TAG_structure_type | DW_TAG_union_type => {
                         let names = di_composite_type
                             .name()
                             .map(|name| (name.to_owned(), sanitize_type_name(name)));
@@ -496,6 +496,12 @@ mod test {
             san,
             b"my_function_3C_aya_bpf_3A__3A_this_3A__3A_is_3A__3A_a_3A__3A_very_3A__3A_long_3A__3A_namespace_3A__3A_BpfContex_94e4085604b3142f"
                 .as_slice()
+        );
+
+        let name = "MaybeUninit<u8>";
+        assert_eq!(
+            sanitize_type_name(name.as_bytes()),
+            b"MaybeUninit_3C_u8_3E_".as_slice()
         );
     }
 }

--- a/tests/btf/assembly/anon_rust.rs
+++ b/tests/btf/assembly/anon_rust.rs
@@ -3,6 +3,9 @@
 
 #![no_std]
 
+// aux-build: loop-panic-handler.rs
+extern crate loop_panic_handler;
+
 use core::marker::PhantomData;
 
 #[repr(transparent)]
@@ -23,11 +26,6 @@ static FOO: Foo = Foo {
     ayy: 0,
     lmao: 0,
 };
-
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
-}
 
 // CHECK: <STRUCT> '<anon>' sz:8 n:2
 // CHECK-NEXT: 'ayy' off:0 --> [{{[0-9]+}}]

--- a/tests/btf/assembly/basic.rs
+++ b/tests/btf/assembly/basic.rs
@@ -5,14 +5,12 @@
 #![no_std]
 #![no_main]
 
+// aux-build: loop-panic-handler.rs
+extern crate loop_panic_handler;
+
 #[no_mangle]
 #[link_section = "uprobe/connect"]
 pub fn connect() {}
-
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
-}
 
 // We check the BTF dump out of btfdump
 // CHECK: <FUNC> 'connect' --> global

--- a/tests/btf/assembly/data-carrying-enum.rs
+++ b/tests/btf/assembly/data-carrying-enum.rs
@@ -3,6 +3,9 @@
 
 #![no_std]
 
+// aux-build: loop-panic-handler.rs
+extern crate loop_panic_handler;
+
 pub enum SimpleEnum {
     First,
     Second,
@@ -28,11 +31,6 @@ pub static X: DataCarryingEnum = DataCarryingEnum::First { a: 54, b: -23 };
 pub static Y: DataCarryingEnum = DataCarryingEnum::Second(54, -23);
 #[no_mangle]
 pub static Z: DataCarryingEnum = DataCarryingEnum::Third(36);
-
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
-}
 
 // The data-carrying enum should be not included in BTF.
 

--- a/tests/btf/assembly/maybe-uninit-union-name.rs
+++ b/tests/btf/assembly/maybe-uninit-union-name.rs
@@ -1,0 +1,13 @@
+// assembly-output: bpf-linker
+// compile-flags: --crate-type cdylib -C link-arg=--emit=obj -C link-arg=--btf -C debuginfo=2
+
+#![no_std]
+
+// aux-build: loop-panic-handler.rs
+extern crate loop_panic_handler;
+
+#[no_mangle]
+pub static GLOBAL: core::mem::MaybeUninit<u8> = core::mem::MaybeUninit::new(1);
+
+// Ensure generic union names are sanitized for BTF compatibility.
+// CHECK: <UNION> 'MaybeUninit_3C_u8_3E_'


### PR DESCRIPTION
Sanitize DI union type names alongside struct names before emitting BTF.
Rust generic unions like MaybeUninit<u8> can otherwise keep characters
that the kernel rejects as invalid BTF names.

Add a regression BTF assembly test that emits a MaybeUninit<u8> global
and asserts the dumped union name is sanitized.

This was provoked by https://github.com/aya-rs/aya/commit/294e0c19413d5.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/346)
<!-- Reviewable:end -->
