### PR TITLE
Align beta with LLVM 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
             llvm: 21
             exclude-features: default,llvm-19,llvm-20,llvm-22,rust-llvm-19,rust-llvm-20,rust-llvm-22
           - rust: beta
-            llvm: 21
-            exclude-features: default,llvm-20,llvm-22,rust-llvm-20,rust-llvm-22
+            llvm: 22
+            exclude-features: llvm-20,llvm-21,rust-llvm-20,rust-llvm-21
           - rust: nightly
             llvm: 22
             exclude-features: llvm-20,llvm-21,rust-llvm-20,rust-llvm-21


### PR DESCRIPTION
Rust 1.94.0 was released on 2026-03-05, which advanced beta to
1.95.0. The failing beta CI logs show that rustc is now producing
LLVM 22 bitcode (`Producer: 'LLVM22.1.0-rust-1.95.0-beta'`).

Match the beta lane to LLVM 22 so bpf-linker reads bitcode with the
same LLVM major version that beta rustc emits. This avoids the
package-backed beta jobs trying to link LLVM 22 bitcode with LLVM 21,
which fails with unknown attribute and invalid record errors.

See https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/.

Co-authored-by: Codex <noreply@openai.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/352)
<!-- Reviewable:end -->
