### PR TITLE
tests: Build a sysroot only if the toolchain lacks the target

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,7 +3,8 @@
 use std::{
     env,
     ffi::{OsStr, OsString},
-    fs,
+    fs, io,
+    os::unix::ffi::{OsStrExt as _, OsStringExt as _},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -109,6 +110,68 @@ fn is_nightly() -> bool {
     output.stdout.windows(NIGHTLY.len()).any(|b| NIGHTLY.eq(b))
 }
 
+/// Returns the active toolchain sysroot if it supports the requested BPF
+/// target.
+///
+/// This currently works only with custom Rust toolchains built with BPF target
+/// support.
+fn toolchain_bpf_sysroot(target: &str) -> Option<PathBuf> {
+    let output = rustc_cmd()
+        .args(["--print", "sysroot"])
+        .output()
+        .expect("failed to determine rustc sysroot");
+    if !output.status.success() {
+        panic!("failed to determine rustc sysroot: {output:?}");
+    }
+
+    let mut sysroot = output.stdout;
+    while matches!(sysroot.last(), Some(b'\n' | b'\r')) {
+        let _newline = sysroot.pop();
+    }
+    let sysroot = PathBuf::from(OsString::from_vec(sysroot));
+    let target_libdir = sysroot.join("lib").join("rustlib").join(target).join("lib");
+
+    let has_core = match fs::read_dir(&target_libdir) {
+        Ok(mut read_dir) => {
+            let has_core = read_dir.any(|entry| {
+                let entry = entry.unwrap_or_else(|err| {
+                    panic!(
+                        "failed to read entry in target libdir {}: {err}",
+                        target_libdir.display()
+                    )
+                });
+                let name = entry.file_name();
+                let name = name.as_os_str().as_bytes();
+                name.starts_with(b"libcore-") && name.ends_with(b".rlib")
+            });
+            if !has_core {
+                eprintln!(
+                    "toolchain sysroot {} has target {} but does not contain libcore; falling back to building a sysroot",
+                    sysroot.display(),
+                    target
+                );
+            }
+            has_core
+        }
+        Err(err) => {
+            if err.kind() == io::ErrorKind::NotFound {
+                eprintln!(
+                    "toolchain sysroot {} does not contain target {target} sysroot {}; falling back to building a sysroot",
+                    sysroot.display(),
+                    target_libdir.display(),
+                );
+                false
+            } else {
+                panic!(
+                    "failed to read target libdir {}: {err}",
+                    target_libdir.display()
+                )
+            }
+        }
+    };
+    has_core.then_some(sysroot)
+}
+
 fn btf_dump(src: &Path, dst: &Path) {
     let dst = fs::File::create(dst)
         .unwrap_or_else(|err| panic!("could not open btf dump file '{}': {err}", dst.display()));
@@ -130,9 +193,10 @@ fn compile_test() {
     let root_dir = Path::new(&root_dir);
     let bpf_sysroot = if let Some(bpf_sysroot) = env::var_os("BPFEL_SYSROOT_DIR") {
         PathBuf::from(bpf_sysroot)
+    } else if let Some(bpf_sysroot) = toolchain_bpf_sysroot(target) {
+        bpf_sysroot
     } else {
-        let rustc = Command::new(env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc")));
-        let rustc_src = rustc_build_sysroot::rustc_sysroot_src(rustc)
+        let rustc_src = rustc_build_sysroot::rustc_sysroot_src(rustc_cmd())
             .expect("could not determine sysroot source directory");
         let directory = root_dir.join("target/sysroot");
         match rustc_build_sysroot::SysrootBuilder::new(&directory, target)


### PR DESCRIPTION
Before attempting to build a sysroot with `rustc-build-sysroot`, check whether the current toolchain already provides one for the BPF target.

This helps package maintainers who ship Rust toolchains with BPF support: `cargo test` works without requiring `BPFEL_SYSROOT_DIR`.

It also avoids incorrect behavior if BPF targets are ever promoted to a higher tier and distributed with prebuilt sysroots by rustup.

Current rustup toolchains still fall back to building a sysroot with `rustc-build-sysroot`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/355)
<!-- Reviewable:end -->
