### PR TITLE
Align CI with stable using LLVM 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,10 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - rust: 1.91.0
+          - rust: 1.90.0
+            llvm: 20
+            exclude-features: default,llvm-21,llvm-22,rust-llvm-21,rust-llvm-22
+          - rust: 1.94.0
             llvm: 21
             exclude-features: default,llvm-20,llvm-22,rust-llvm-20,rust-llvm-22
           - rust: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,8 +237,8 @@ jobs:
             llvm: 21
             exclude-features: default,llvm-20,llvm-22,rust-llvm-20,rust-llvm-22
           - rust: stable
-            llvm: 21
-            exclude-features: default,llvm-20,llvm-22,rust-llvm-20,rust-llvm-22
+            llvm: 22
+            exclude-features: llvm-20,llvm-21,rust-llvm-20,rust-llvm-21
           - rust: beta
             llvm: 22
             exclude-features: llvm-20,llvm-21,rust-llvm-20,rust-llvm-21


### PR DESCRIPTION
- **Align stable with LLVM 22**
- **Test pinned Rust LLVM versions**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/360)
<!-- Reviewable:end -->
