### PR TITLE
di: Use safe wrappers consistently

### DIFF
--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -23,7 +23,7 @@ use crate::llvm::{LLVMContext, LLVMModule, iter::*, types::di::DISubprogram};
 const MAX_KSYM_NAME_LEN: usize = 128;
 
 pub(crate) struct DISanitizer<'ctx> {
-    context: LLVMContextRef,
+    context: &'ctx LLVMContext,
     module: LLVMModuleRef,
     builder: LLVMDIBuilderRef,
     visited_nodes: HashSet<u64>,
@@ -61,7 +61,7 @@ fn sanitize_type_name(name: &[u8]) -> Vec<u8> {
 impl<'ctx> DISanitizer<'ctx> {
     pub(crate) fn new(context: &'ctx LLVMContext, module: &mut LLVMModule<'ctx>) -> Self {
         DISanitizer {
-            context: context.as_mut_ptr(),
+            context,
             module: module.as_mut_ptr(),
             builder: unsafe { LLVMCreateDIBuilder(module.as_mut_ptr()) },
             visited_nodes: HashSet::new(),
@@ -219,7 +219,9 @@ impl<'ctx> DISanitizer<'ctx> {
             // seen its value or not, since the same value can appear as an operand in multiple
             // nodes in the tree.
             if let Some(new_metadata) = self.replace_operands.get(&value_id) {
-                operand.replace(unsafe { LLVMMetadataAsValue(self.context, *new_metadata) })
+                operand.replace(unsafe {
+                    LLVMMetadataAsValue(self.context.as_mut_ptr(), *new_metadata)
+                })
             }
         }
 
@@ -245,7 +247,8 @@ impl<'ctx> DISanitizer<'ctx> {
 
         if let Some(entries) = value.metadata_entries() {
             for (index, (metadata, kind)) in entries.iter().enumerate() {
-                let metadata_value = unsafe { LLVMMetadataAsValue(self.context, metadata) };
+                let metadata_value =
+                    unsafe { LLVMMetadataAsValue(self.context.as_mut_ptr(), metadata) };
                 self.visit_item(Item::MetadataEntry(metadata_value, kind, index));
             }
         }
@@ -318,7 +321,7 @@ impl<'ctx> DISanitizer<'ctx> {
             }
 
             // Skip functions that don't have subprograms.
-            let Some(mut subprogram) = function.subprogram(self.context) else {
+            let Some(mut subprogram) = function.subprogram(self.context.as_mut_ptr()) else {
                 continue;
             };
 
@@ -354,7 +357,10 @@ impl<'ctx> DISanitizer<'ctx> {
                 // replace retained nodes manually below.
                 LLVMDIBuilderFinalizeSubprogram(self.builder, new_program);
 
-                DISubprogram::from_value_ref(LLVMMetadataAsValue(self.context, new_program))
+                DISubprogram::from_value_ref(LLVMMetadataAsValue(
+                    self.context.as_mut_ptr(),
+                    new_program,
+                ))
             };
 
             // Point the function to the new subprogram.
@@ -376,7 +382,8 @@ impl<'ctx> DISanitizer<'ctx> {
             // Remove retained nodes from the old program or we'll hit a debug assertion since
             // its debug variables no longer point to the program. See the
             // NumAbstractSubprograms assertion in DwarfDebug::endFunctionImpl in LLVM.
-            let empty_node = unsafe { LLVMMDNodeInContext2(self.context, ptr::null_mut(), 0) };
+            let empty_node =
+                unsafe { LLVMMDNodeInContext2(self.context.as_mut_ptr(), ptr::null_mut(), 0) };
             subprogram.set_retained_nodes(empty_node);
 
             assert_eq!(

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -3,7 +3,6 @@ use std::{
     collections::{HashMap, HashSet, hash_map::DefaultHasher},
     hash::Hasher as _,
     io::Write as _,
-    marker::PhantomData,
     ptr,
 };
 
@@ -24,13 +23,11 @@ const MAX_KSYM_NAME_LEN: usize = 128;
 
 pub(crate) struct DISanitizer<'ctx> {
     context: &'ctx LLVMContext,
-    module: LLVMModuleRef,
+    module: &'ctx LLVMModule<'ctx>,
     builder: LLVMDIBuilderRef,
     visited_nodes: HashSet<u64>,
     replace_operands: HashMap<u64, LLVMMetadataRef>,
     skipped_types_lossy: Vec<String>,
-    // TODO: use references of safe wrappers instead of PhantomData
-    _marker: PhantomData<LLVMModule<'ctx>>,
 }
 
 // Sanitize Rust type names to be valid C type names.
@@ -59,15 +56,14 @@ fn sanitize_type_name(name: &[u8]) -> Vec<u8> {
 }
 
 impl<'ctx> DISanitizer<'ctx> {
-    pub(crate) fn new(context: &'ctx LLVMContext, module: &mut LLVMModule<'ctx>) -> Self {
+    pub(crate) fn new(context: &'ctx LLVMContext, module: &'ctx LLVMModule<'ctx>) -> Self {
         DISanitizer {
             context,
-            module: module.as_mut_ptr(),
+            module,
             builder: unsafe { LLVMCreateDIBuilder(module.as_mut_ptr()) },
             visited_nodes: HashSet::new(),
             replace_operands: HashMap::new(),
             skipped_types_lossy: Vec::new(),
-            _marker: PhantomData,
         }
     }
 
@@ -273,14 +269,14 @@ impl<'ctx> DISanitizer<'ctx> {
 
         self.replace_operands = self.fix_subprogram_linkage(exported_symbols);
 
-        for value in module.globals_iter() {
+        for value in module.globals() {
             self.visit_item(Item::GlobalVariable(value));
         }
-        for value in module.global_aliases_iter() {
+        for value in module.global_aliases() {
             self.visit_item(Item::GlobalAlias(value));
         }
 
-        for function in module.functions_iter() {
+        for function in module.functions() {
             self.visit_item(Item::Function(function));
         }
 
@@ -313,7 +309,7 @@ impl<'ctx> DISanitizer<'ctx> {
 
         for mut function in self
             .module
-            .functions_iter()
+            .functions()
             .map(|value| unsafe { Function::from_value_ref(value) })
         {
             if export_symbols.contains(function.name()) {

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -14,7 +14,7 @@ use super::types::{
     di::DIType,
     ir::{Function, MDNode, Metadata, Value},
 };
-use crate::llvm::{LLVMContext, LLVMModule, iter::*, types::di::DISubprogram};
+use crate::llvm::{DIBuilder, LLVMContext, LLVMModule, iter::*};
 
 // KSYM_NAME_LEN from linux kernel intentionally set
 // to lower value found across kernel versions to ensure
@@ -24,7 +24,7 @@ const MAX_KSYM_NAME_LEN: usize = 128;
 pub(crate) struct DISanitizer<'ctx> {
     context: &'ctx LLVMContext,
     module: &'ctx LLVMModule<'ctx>,
-    builder: LLVMDIBuilderRef,
+    builder: DIBuilder<'ctx>,
     visited_nodes: HashSet<u64>,
     replace_operands: HashMap<u64, LLVMMetadataRef>,
     skipped_types_lossy: Vec<String>,
@@ -60,7 +60,7 @@ impl<'ctx> DISanitizer<'ctx> {
         DISanitizer {
             context,
             module,
-            builder: unsafe { LLVMCreateDIBuilder(module.as_mut_ptr()) },
+            builder: DIBuilder::new(module),
             visited_nodes: HashSet::new(),
             replace_operands: HashMap::new(),
             skipped_types_lossy: Vec::new(),
@@ -321,43 +321,28 @@ impl<'ctx> DISanitizer<'ctx> {
                 continue;
             };
 
-            let (name, name_len) = subprogram
-                .name()
-                .map_or((ptr::null(), 0), |s| (s.as_ptr(), s.len()));
-            let (linkage_name, linkage_name_len) = subprogram
-                .linkage_name()
-                .map_or((ptr::null(), 0), |s| (s.as_ptr(), s.len()));
             let ty = subprogram.ty();
 
             // Create a new subprogram that has DISPFlagLocalToUnit set, so the BTF backend emits it
             // with linkage=static
-            let mut new_program = unsafe {
-                let new_program = LLVMDIBuilderCreateFunction(
-                    self.builder,
-                    subprogram.scope().unwrap(),
-                    name.cast(),
-                    name_len,
-                    linkage_name.cast(),
-                    linkage_name_len,
-                    subprogram.file(),
-                    subprogram.line(),
-                    ty,
-                    1,
-                    1,
-                    subprogram.line(),
-                    subprogram.type_flags(),
-                    1,
-                );
-                // Technically this must be called as part of the builder API, but effectively does
-                // nothing because we don't add any variables through the builder API, instead we
-                // replace retained nodes manually below.
-                LLVMDIBuilderFinalizeSubprogram(self.builder, new_program);
-
-                DISubprogram::from_value_ref(LLVMMetadataAsValue(
-                    self.context.as_mut_ptr(),
-                    new_program,
-                ))
-            };
+            let mut new_program = self.builder.create_function(
+                self.context,
+                subprogram.scope().unwrap(),
+                subprogram.name(),
+                subprogram.linkage_name(),
+                subprogram.file(),
+                subprogram.line(),
+                ty,
+                true,
+                true,
+                subprogram.line(),
+                subprogram.type_flags(),
+                true,
+            );
+            // Technically this must be called as part of the builder API, but effectively does
+            // nothing because we don't add any variables through the builder API, instead we
+            // replace retained nodes manually below.
+            self.builder.finalize_subprogram(&new_program);
 
             // Point the function to the new subprogram.
             function.set_subprogram(&new_program);
@@ -391,12 +376,6 @@ impl<'ctx> DISanitizer<'ctx> {
         }
 
         replace
-    }
-}
-
-impl Drop for DISanitizer<'_> {
-    fn drop(&mut self) {
-        unsafe { LLVMDisposeDIBuilder(self.builder) };
     }
 }
 

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -45,6 +45,7 @@ use llvm_sys::{
 use tracing::{debug, error};
 pub(crate) use types::{
     context::{InstalledDiagnosticHandler, LLVMContext},
+    di_builder::DIBuilder,
     memory_buffer::MemoryBuffer,
     module::LLVMModule,
     target_machine::LLVMTargetMachine,

--- a/src/llvm/types/di.rs
+++ b/src/llvm/types/di.rs
@@ -8,12 +8,12 @@ use llvm_sys::{
         LLVMDITypeGetFlags, LLVMDITypeGetLine, LLVMDITypeGetName, LLVMDITypeGetOffsetInBits,
         LLVMGetDINodeTag,
     },
-    prelude::{LLVMContextRef, LLVMMetadataRef, LLVMValueRef},
+    prelude::{LLVMMetadataRef, LLVMValueRef},
 };
 
 use crate::llvm::{
-    LLVMGetMDString,
     types::ir::{MDNode, Metadata},
+    LLVMContext, LLVMGetMDString,
 };
 
 fn mdstring<'a>(mdstring: LLVMValueRef) -> &'a [u8] {
@@ -205,8 +205,13 @@ impl DIDerivedType<'_> {
     ///
     /// Returns a `NulError` if the new name contains a NUL byte, as it cannot
     /// be converted into a `CString`.
-    pub(crate) fn replace_name(&mut self, context: LLVMContextRef, name: &[u8]) {
-        super::ir::replace_name(self.value_ref, context, DITypeOperand::Name as u32, name)
+    pub(crate) fn replace_name(&mut self, context: &LLVMContext, name: &[u8]) {
+        super::ir::replace_name(
+            self.value_ref,
+            context.as_mut_ptr(),
+            DITypeOperand::Name as u32,
+            name,
+        )
     }
 
     /// Returns a DWARF tag of the given derived type.
@@ -317,8 +322,13 @@ impl DICompositeType<'_> {
     ///
     /// Returns a `NulError` if the new name contains a NUL byte, as it cannot
     /// be converted into a `CString`.
-    pub(crate) fn replace_name(&mut self, context: LLVMContextRef, name: &[u8]) {
-        super::ir::replace_name(self.value_ref, context, DITypeOperand::Name as u32, name)
+    pub(crate) fn replace_name(&mut self, context: &LLVMContext, name: &[u8]) {
+        super::ir::replace_name(
+            self.value_ref,
+            context.as_mut_ptr(),
+            DITypeOperand::Name as u32,
+            name,
+        )
     }
 
     /// Returns a DWARF tag of the given composite type.
@@ -401,10 +411,10 @@ impl DISubprogram<'_> {
     ///
     /// Returns a `NulError` if the new name contains a NUL byte, as it cannot
     /// be converted into a `CString`.
-    pub(crate) fn replace_name(&mut self, context: LLVMContextRef, name: &[u8]) {
+    pub(crate) fn replace_name(&mut self, context: &LLVMContext, name: &[u8]) {
         super::ir::replace_name(
             self.value_ref,
-            context,
+            context.as_mut_ptr(),
             DISubprogramOperand::Name as u32,
             name,
         )

--- a/src/llvm/types/di.rs
+++ b/src/llvm/types/di.rs
@@ -12,8 +12,8 @@ use llvm_sys::{
 };
 
 use crate::llvm::{
-    types::ir::{MDNode, Metadata},
     LLVMContext, LLVMGetMDString,
+    types::ir::{MDNode, Metadata},
 };
 
 fn mdstring<'a>(mdstring: LLVMValueRef) -> &'a [u8] {

--- a/src/llvm/types/di_builder.rs
+++ b/src/llvm/types/di_builder.rs
@@ -1,0 +1,86 @@
+use std::marker::PhantomData;
+
+use llvm_sys::{
+    core::LLVMMetadataAsValue,
+    debuginfo::{
+        LLVMCreateDIBuilder, LLVMDIBuilderCreateFunction, LLVMDIBuilderFinalizeSubprogram,
+        LLVMDisposeDIBuilder,
+    },
+    prelude::{LLVMDIBuilderRef, LLVMMetadataRef},
+};
+
+use crate::llvm::{LLVMContext, LLVMModule, types::di::DISubprogram};
+
+pub(crate) struct DIBuilder<'ctx> {
+    builder: LLVMDIBuilderRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+impl<'ctx> DIBuilder<'ctx> {
+    pub(crate) fn new(module: &'ctx LLVMModule<'ctx>) -> Self {
+        let builder = unsafe { LLVMCreateDIBuilder(module.as_mut_ptr()) };
+        Self {
+            builder,
+            _marker: PhantomData,
+        }
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    pub(crate) fn create_function(
+        &self,
+        context: &'ctx LLVMContext,
+        scope: LLVMMetadataRef,
+        name: Option<&[u8]>,
+        linkage_name: Option<&[u8]>,
+        file: LLVMMetadataRef,
+        line: u32,
+        ty: LLVMMetadataRef,
+        is_local_to_unit: bool,
+        is_definition: bool,
+        scope_line: u32,
+        flags: i32,
+        is_optimized: bool,
+    ) -> DISubprogram<'ctx> {
+        let (name, name_len) = name.map_or((std::ptr::null(), 0), |s| (s.as_ptr(), s.len()));
+        let (linkage_name, linkage_name_len) =
+            linkage_name.map_or((std::ptr::null(), 0), |s| (s.as_ptr(), s.len()));
+
+        let subprogram = unsafe {
+            LLVMDIBuilderCreateFunction(
+                self.builder,
+                scope,
+                name.cast(),
+                name_len,
+                linkage_name.cast(),
+                linkage_name_len,
+                file,
+                line,
+                ty,
+                i32::from(is_local_to_unit),
+                i32::from(is_definition),
+                scope_line,
+                flags,
+                i32::from(is_optimized),
+            )
+        };
+
+        unsafe {
+            DISubprogram::from_value_ref(LLVMMetadataAsValue(context.as_mut_ptr(), subprogram))
+        }
+    }
+
+    pub(crate) fn finalize_subprogram(&self, subprogram: &DISubprogram<'_>) {
+        unsafe {
+            LLVMDIBuilderFinalizeSubprogram(
+                self.builder,
+                llvm_sys::core::LLVMValueAsMetadata(subprogram.value_ref),
+            )
+        };
+    }
+}
+
+impl Drop for DIBuilder<'_> {
+    fn drop(&mut self) {
+        unsafe { LLVMDisposeDIBuilder(self.builder) };
+    }
+}

--- a/src/llvm/types/ir.rs
+++ b/src/llvm/types/ir.rs
@@ -16,7 +16,7 @@ use llvm_sys::{
 };
 
 use crate::llvm::{
-    Message,
+    LLVMContext, Message,
     iter::IterBasicBlocks as _,
     symbol_name,
     types::di::{DICompositeType, DIDerivedType, DISubprogram, DIType},
@@ -221,9 +221,10 @@ impl MDNode<'_> {
     }
 
     /// Constructs an empty metadata node.
-    pub(crate) fn empty(context: LLVMContextRef) -> Self {
-        let metadata = unsafe { LLVMMDNodeInContext2(context, core::ptr::null_mut(), 0) };
-        unsafe { Self::from_metadata_ref(context, metadata) }
+    pub(crate) fn empty(context: &LLVMContext) -> Self {
+        let metadata =
+            unsafe { LLVMMDNodeInContext2(context.as_mut_ptr(), core::ptr::null_mut(), 0) };
+        unsafe { Self::from_metadata_ref(context.as_mut_ptr(), metadata) }
     }
 
     /// Constructs a new metadata node from an array of [`DIType`] elements.
@@ -231,19 +232,19 @@ impl MDNode<'_> {
     /// This function is used to create composite metadata structures, such as
     /// arrays or tuples of different types or values, which can then be used
     /// to represent complex data structures within the metadata system.
-    pub(crate) fn with_elements(context: LLVMContextRef, elements: &[DIType<'_>]) -> Self {
+    pub(crate) fn with_elements(context: &LLVMContext, elements: &[DIType<'_>]) -> Self {
         let metadata = unsafe {
             let mut elements: Vec<LLVMMetadataRef> = elements
                 .iter()
                 .map(|di_type| LLVMValueAsMetadata(di_type.value_ref))
                 .collect();
             LLVMMDNodeInContext2(
-                context,
+                context.as_mut_ptr(),
                 elements.as_mut_slice().as_mut_ptr(),
                 elements.len(),
             )
         };
-        unsafe { Self::from_metadata_ref(context, metadata) }
+        unsafe { Self::from_metadata_ref(context.as_mut_ptr(), metadata) }
     }
 }
 

--- a/src/llvm/types/mod.rs
+++ b/src/llvm/types/mod.rs
@@ -1,5 +1,6 @@
 pub(super) mod context;
 pub(super) mod di;
+pub(super) mod di_builder;
 pub(super) mod ir;
 pub(super) mod memory_buffer;
 pub(super) mod module;

--- a/src/llvm/types/module.rs
+++ b/src/llvm/types/module.rs
@@ -8,10 +8,14 @@ use llvm_sys::{
         LLVMGetTarget, LLVMPrintModuleToFile, LLVMPrintModuleToString,
     },
     debuginfo::LLVMStripModuleDebugInfo,
-    prelude::LLVMModuleRef,
+    prelude::{LLVMModuleRef, LLVMValueRef},
 };
 
-use crate::llvm::{MemoryBuffer, Message, types::context::LLVMContext};
+use crate::llvm::{
+    MemoryBuffer, Message,
+    iter::{IterModuleFunctions as _, IterModuleGlobalAliases as _, IterModuleGlobals as _},
+    types::context::LLVMContext,
+};
 
 pub(crate) struct LLVMModule<'ctx> {
     pub(super) module: LLVMModuleRef,
@@ -82,6 +86,18 @@ impl LLVMModule<'_> {
     /// strips debug information, returns true if DI got stripped
     pub(crate) fn strip_debug_info(&mut self) -> bool {
         unsafe { LLVMStripModuleDebugInfo(self.module) != 0 }
+    }
+
+    pub(crate) fn functions(&self) -> impl Iterator<Item = LLVMValueRef> {
+        self.module.functions_iter()
+    }
+
+    pub(crate) fn globals(&self) -> impl Iterator<Item = LLVMValueRef> {
+        self.module.globals_iter()
+    }
+
+    pub(crate) fn global_aliases(&self) -> impl Iterator<Item = LLVMValueRef> {
+        self.module.global_aliases_iter()
     }
 }
 


### PR DESCRIPTION
Avoid usage of `LLVM*Ref` pointer types in favor of safe wrappers. See individual commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/361)
<!-- Reviewable:end -->
