### PR TITLE
[WIP] feat: CO-RE/BTF relocations

### DIFF
--- a/src/linker.rs
+++ b/src/linker.rs
@@ -55,6 +55,11 @@ pub enum LinkerError {
     #[error("LLVMRunPasses failed: {0}")]
     OptimizeError(String),
 
+    /// Rewriting CO-RE relocations failed.
+    #[cfg(feature = "llvm-22")]
+    #[error("failed to rewrite CO-RE relocations: {0}")]
+    CoreRelocError(llvm::CoreRelocError),
+
     /// Generating the BPF code failed.
     #[error("LLVMTargetMachineEmitToFile failed: {0}")]
     EmitCodeError(String),
@@ -709,8 +714,19 @@ where
     // programs and maps and remove dead code.
 
     if *btf {
-        // if we want to emit BTF, we need to sanitize the debug information
-        llvm::DISanitizer::new(context, module).run(&export_symbols);
+        // If we want to emit BTF, we need to sanitize the debug information
+        // and emit relocations.
+        let preserve_access_types = llvm::DISanitizer::new(context, module).run(&export_symbols);
+        #[cfg(not(feature = "llvm-22"))]
+        let _ = &preserve_access_types;
+        // CO-RE relocations rely on debug info record API that was introduced
+        // in LLVM 22:
+        // https://llvm.org/docs/RemoveDIsDebugInfo.html
+        #[cfg(feature = "llvm-22")]
+        if !preserve_access_types.is_empty() {
+            let mut pass = llvm::CoreRelocPass::new(context, module, &preserve_access_types);
+            pass.run().map_err(LinkerError::CoreRelocError)?;
+        }
     } else {
         // if we don't need BTF emission, we can strip DI
         let ok = module.strip_debug_info();

--- a/src/llvm/core_reloc.rs
+++ b/src/llvm/core_reloc.rs
@@ -1,0 +1,999 @@
+use std::{
+    collections::{HashMap, HashSet},
+    ffi::CStr,
+};
+
+use gimli::{DW_TAG_array_type, DW_TAG_pointer_type, DW_TAG_union_type};
+use llvm_sys::{
+    LLVMDbgRecordKind, LLVMOpcode, LLVMTypeKind,
+    core::{
+        LLVMArrayType2, LLVMConstInt, LLVMConstIntGetZExtValue, LLVMCreateTypeAttribute,
+        LLVMGetElementType, LLVMGetEnumAttributeKindForName, LLVMGetGEPSourceElementType,
+        LLVMGetInstructionOpcode, LLVMGetIntTypeWidth, LLVMGetIntrinsicDeclaration,
+        LLVMGetIntrinsicID, LLVMGetNumArgOperands, LLVMGetNumOperands, LLVMGetOperand,
+        LLVMGetTypeKind, LLVMInstructionEraseFromParent, LLVMInt8TypeInContext,
+        LLVMInt32TypeInContext, LLVMIntTypeInContext, LLVMIsAConstantInt, LLVMIsAInstruction,
+        LLVMLookupIntrinsicID, LLVMPointerType, LLVMReplaceAllUsesWith, LLVMSetOperand,
+        LLVMStructGetTypeAtIndex, LLVMStructTypeInContext, LLVMTypeOf,
+    },
+    debuginfo::{LLVMDITypeGetSizeInBits, LLVMGetMetadataKind, LLVMMetadataKind},
+    prelude::LLVMValueRef,
+};
+use thiserror::Error;
+
+use crate::llvm::{
+    DataLayout, IRBuilder, LLVMContext, LLVMModule,
+    types::{
+        di::{DICompositeType, DIDerivedType, DISubroutineType},
+        instruction::{
+            CallInst, GetElementPtrInst, Instruction as _, InstructionKind, LoadInst, StoreInst,
+        },
+        ir::Metadata,
+    },
+};
+
+const ELEMENTTYPE: &CStr = c"elementtype";
+// Metadata kind attached to preserve-access intrinsic calls. The metadata payload carries the
+// debug-info type used by BPF CO-RE relocation handling.
+const PRESERVE_ACCESS_MD_NAME: &CStr = c"llvm.preserve.access.index";
+// Intrinsic name for an array-element access. This preserves the selected array index and the
+// element type through the CO-RE relocation pipeline.
+const PRESERVE_ARRAY_ACCESS_INTRINSIC_NAME: &CStr = c"llvm.preserve.array.access.index";
+// Intrinsic name for a struct-member access that behaves like a struct GEP while preserving
+// relocation-relevant access indices.
+const PRESERVE_STRUCT_ACCESS_INTRINSIC_NAME: &CStr = c"llvm.preserve.struct.access.index";
+// Intrinsic name for a union-member access. Unlike the struct variant, this identifies the
+// selected member by field index without an `elementtype` attribute.
+const PRESERVE_UNION_ACCESS_INTRINSIC_NAME: &CStr = c"llvm.preserve.union.access.index";
+const DBG_VALUE_INTRINSIC_NAME: &CStr = c"llvm.dbg.value";
+const BITS_PER_BYTE: u64 = 8;
+const DILOCAL_VARIABLE_TYPE_OPERAND: u32 = 3;
+
+pub(crate) struct CoreRelocPass<'ctx, 'module, 'types> {
+    context: &'ctx LLVMContext,
+    module: &'module mut LLVMModule<'ctx>,
+    builder: IRBuilder<'ctx>,
+    data_layout: DataLayout<'ctx>,
+    preserve_access_md_kind: u32,
+    elementtype_attr_kind: u32,
+    dbg_value_intrinsic_id: u32,
+    preserve_access_types: &'types HashSet<usize>,
+    pointer_types: HashMap<LLVMValueRef, LLVMValueRef>,
+    synthetic_types: HashMap<LLVMValueRef, llvm_sys::prelude::LLVMTypeRef>,
+}
+
+struct ResolvedAccess {
+    base: LLVMValueRef,
+    composite_type: LLVMValueRef,
+    offset_bytes: u64,
+}
+
+struct FieldMatch {
+    member: LLVMValueRef,
+    member_index: u32,
+}
+
+struct ContainingMemberMatch {
+    member_index: u32,
+    nested_composite: LLVMValueRef,
+    remainder_bytes: u64,
+}
+
+struct AccessPath {
+    ptr: LLVMValueRef,
+    nested_composite: Option<LLVMValueRef>,
+}
+
+#[derive(Debug, Error)]
+pub enum CoreRelocError {
+    #[error("failed to compute GEP offset: {0}")]
+    GepOffset(#[from] GepOffsetError),
+    #[error("failed to build array access path: {0}")]
+    ArrayAccess(#[from] ArrayAccessError),
+}
+
+#[derive(Debug, Error)]
+#[expect(missing_copy_implementations, reason = "not needed")]
+pub enum GepOffsetError {
+    #[error("index operand is not a constant integer")]
+    NonConstantIndex,
+    #[error("invalid struct field index")]
+    BadStructIndex,
+    #[error("byte offset overflow")]
+    OffsetOverflow,
+    #[error("unsupported indexed type kind")]
+    UnsupportedTypeKind,
+}
+
+#[derive(Debug, Error)]
+#[expect(missing_copy_implementations, reason = "not needed")]
+pub enum ArrayAccessError {
+    #[error("array element type is missing")]
+    MissingElementType,
+    #[error("array element size is not byte-aligned")]
+    NonByteAlignedElementSize,
+    #[error("array element size is zero")]
+    ZeroSizedElement,
+    #[error("array index does not fit into u32")]
+    IndexOverflow,
+}
+
+impl<'ctx, 'module, 'types> CoreRelocPass<'ctx, 'module, 'types> {
+    pub(crate) fn new(
+        context: &'ctx LLVMContext,
+        module: &'module mut LLVMModule<'ctx>,
+        preserve_access_types: &'types HashSet<usize>,
+    ) -> Self {
+        let data_layout = module.data_layout();
+        let preserve_access_md_kind = context.md_kind_id(PRESERVE_ACCESS_MD_NAME);
+        Self {
+            context,
+            module,
+            builder: IRBuilder::new(context),
+            data_layout,
+            preserve_access_md_kind,
+            elementtype_attr_kind: unsafe {
+                LLVMGetEnumAttributeKindForName(ELEMENTTYPE.as_ptr(), ELEMENTTYPE.to_bytes().len())
+            },
+            dbg_value_intrinsic_id: unsafe {
+                LLVMLookupIntrinsicID(
+                    DBG_VALUE_INTRINSIC_NAME.as_ptr().cast(),
+                    DBG_VALUE_INTRINSIC_NAME.to_bytes().len(),
+                )
+            },
+            preserve_access_types,
+            pointer_types: HashMap::new(),
+            synthetic_types: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn run(&mut self) -> Result<(), CoreRelocError> {
+        let functions: Vec<_> = self.module.functions().collect();
+        for function in functions {
+            self.pointer_types.clear();
+
+            if let Some(subprogram) = function.subprogram(self.context.as_mut_ptr()) {
+                let subroutine_type = unsafe {
+                    DISubroutineType::from_metadata_ref(self.context.as_mut_ptr(), subprogram.ty())
+                };
+
+                for (param, metadata) in function.params().zip(subroutine_type.type_array().skip(1))
+                {
+                    let Some(metadata) = metadata else {
+                        continue;
+                    };
+                    let Some(composite) = self.pointer_composite_from_metadata(metadata) else {
+                        continue;
+                    };
+                    let _prev = self.pointer_types.insert(param, composite);
+                }
+            }
+
+            let basic_blocks: Vec<_> = function.basic_blocks().collect();
+            let mut declared_pointer_slots = HashMap::new();
+            let mut pending_pointer_stores = HashMap::<LLVMValueRef, Vec<LLVMValueRef>>::new();
+
+            for bb in &basic_blocks {
+                for instruction in bb.instructions() {
+                    self.seed_dbg_records(
+                        &instruction,
+                        &mut declared_pointer_slots,
+                        &mut pending_pointer_stores,
+                    );
+                    self.seed_dbg_value(&instruction);
+                    self.seed_store_pointer_type(
+                        &instruction,
+                        &declared_pointer_slots,
+                        &mut pending_pointer_stores,
+                    );
+                }
+            }
+
+            for bb in &basic_blocks {
+                for instruction in bb.instructions() {
+                    match instruction {
+                        InstructionKind::LoadInst(load_inst) => self.rewrite_load(load_inst)?,
+                        InstructionKind::StoreInst(store_inst) => self.rewrite_store(store_inst)?,
+                        InstructionKind::GetElementPtrInst(gep_inst) => {
+                            self.rewrite_gep(gep_inst)?
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn seed_dbg_records(
+        &mut self,
+        instruction: &InstructionKind<'_>,
+        declared_pointer_slots: &mut HashMap<LLVMValueRef, LLVMValueRef>,
+        pending_pointer_stores: &mut HashMap<LLVMValueRef, Vec<LLVMValueRef>>,
+    ) {
+        for record in instruction.dbg_records() {
+            match record.kind() {
+                LLVMDbgRecordKind::LLVMDbgRecordValue => {
+                    let value = record.value(0);
+                    let variable_md = record.variable();
+                    self.seed_pointer_type_from_variable(value, variable_md);
+                }
+                LLVMDbgRecordKind::LLVMDbgRecordDeclare => {
+                    let slot = record.value(0);
+                    let variable_md = record.variable();
+                    let Some(composite) = self.pointer_composite_from_variable(variable_md) else {
+                        continue;
+                    };
+
+                    let _prev = declared_pointer_slots.insert(slot, composite);
+                    if let Some(values) = pending_pointer_stores.remove(&slot) {
+                        for value in values {
+                            let _prev = self.pointer_types.insert(value, composite);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn seed_dbg_value(&mut self, instruction: &InstructionKind<'_>) {
+        if instruction.opcode() != LLVMOpcode::LLVMCall {
+            return;
+        }
+
+        let callee = instruction.called_value();
+        if callee.is_null()
+            || unsafe { LLVMGetIntrinsicID(callee) } != self.dbg_value_intrinsic_id
+            || unsafe { LLVMGetNumArgOperands(instruction.value_ref()) } < 2
+        {
+            return;
+        }
+
+        let args: Vec<_> = instruction.args().collect();
+        let (value, variable) = match args.as_slice() {
+            [value, variable] => (*value, *variable),
+            _ => return,
+        };
+        if value.is_null() || variable.is_null() {
+            return;
+        }
+
+        let variable_md = unsafe { llvm_sys::core::LLVMValueAsMetadata(variable) };
+        self.seed_pointer_type_from_variable(value, variable_md);
+    }
+
+    fn seed_pointer_type_from_variable(
+        &mut self,
+        value: LLVMValueRef,
+        variable_md: llvm_sys::prelude::LLVMMetadataRef,
+    ) {
+        if value.is_null() {
+            return;
+        }
+
+        let Some(composite) = self.pointer_composite_from_variable(variable_md) else {
+            return;
+        };
+
+        let _prev = self.pointer_types.insert(value, composite);
+    }
+
+    fn seed_store_pointer_type(
+        &mut self,
+        instruction: &InstructionKind<'_>,
+        declared_pointer_slots: &HashMap<LLVMValueRef, LLVMValueRef>,
+        pending_pointer_stores: &mut HashMap<LLVMValueRef, Vec<LLVMValueRef>>,
+    ) {
+        if instruction.opcode() != LLVMOpcode::LLVMStore {
+            return;
+        }
+
+        let slot = unsafe { LLVMGetOperand(instruction.value_ref(), 1) };
+        let value = unsafe { LLVMGetOperand(instruction.value_ref(), 0) };
+        if let Some(&composite) = declared_pointer_slots.get(&slot) {
+            let _prev = self.pointer_types.insert(value, composite);
+        } else {
+            pending_pointer_stores.entry(slot).or_default().push(value);
+        }
+    }
+
+    fn pointer_composite_from_variable(
+        &self,
+        variable_md: llvm_sys::prelude::LLVMMetadataRef,
+    ) -> Option<LLVMValueRef> {
+        if variable_md.is_null()
+            || !matches!(
+                unsafe { LLVMGetMetadataKind(variable_md) },
+                LLVMMetadataKind::LLVMDILocalVariableMetadataKind
+            )
+        {
+            return None;
+        }
+
+        let variable =
+            unsafe { llvm_sys::core::LLVMMetadataAsValue(self.context.as_mut_ptr(), variable_md) };
+        let variable_type = unsafe { LLVMGetOperand(variable, DILOCAL_VARIABLE_TYPE_OPERAND) };
+        if variable_type.is_null() {
+            return None;
+        }
+
+        self.pointer_composite_from_metadata(unsafe { Metadata::from_value_ref(variable_type) })
+    }
+
+    fn rewrite_load(&mut self, mut load: LoadInst<'_>) -> Result<(), CoreRelocError> {
+        let Some(resolved) = self.resolve_access(load.pointer())? else {
+            return Ok(());
+        };
+
+        let Some(access_path) = self.build_access_path(
+            load.value_ref(),
+            resolved.base,
+            resolved.composite_type,
+            resolved.offset_bytes,
+            Some(unsafe { LLVMTypeOf(load.value_ref()) }),
+        )?
+        else {
+            return Ok(());
+        };
+        load.set_pointer(access_path.ptr);
+
+        if self.is_pointer_type(unsafe { LLVMTypeOf(load.value_ref()) })
+            && let Some(pointee) = access_path.nested_composite
+        {
+            let _prev = self.pointer_types.insert(load.value_ref(), pointee);
+        }
+
+        Ok(())
+    }
+
+    fn rewrite_store(&mut self, store: StoreInst<'_>) -> Result<(), CoreRelocError> {
+        let Some(resolved) = self.resolve_access(store.pointer())? else {
+            return Ok(());
+        };
+
+        let stored_value = store.value();
+        let Some(access_path) = self.build_access_path(
+            store.value_ref(),
+            resolved.base,
+            resolved.composite_type,
+            resolved.offset_bytes,
+            Some(unsafe { LLVMTypeOf(stored_value) }),
+        )?
+        else {
+            return Ok(());
+        };
+        unsafe { LLVMSetOperand(store.value_ref(), 1, access_path.ptr) };
+
+        Ok(())
+    }
+
+    fn rewrite_gep(&mut self, gep: GetElementPtrInst<'_>) -> Result<(), CoreRelocError> {
+        let Some(resolved) = self.resolve_access(gep.value_ref())? else {
+            return Ok(());
+        };
+
+        let composite = unsafe { DICompositeType::from_value_ref(resolved.composite_type) };
+        if resolved.offset_bytes == 0 && composite.tag() != DW_TAG_array_type {
+            return Ok(());
+        }
+
+        let Some(access_path) = self.build_access_path(
+            gep.value_ref(),
+            resolved.base,
+            resolved.composite_type,
+            resolved.offset_bytes,
+            None,
+        )?
+        else {
+            return Ok(());
+        };
+
+        if let Some(nested) = access_path.nested_composite {
+            let _prev = self.pointer_types.insert(access_path.ptr, nested);
+        }
+
+        unsafe {
+            LLVMReplaceAllUsesWith(gep.value_ref(), access_path.ptr);
+            LLVMInstructionEraseFromParent(gep.value_ref());
+        }
+
+        Ok(())
+    }
+
+    fn resolve_access(
+        &self,
+        value: LLVMValueRef,
+    ) -> Result<Option<ResolvedAccess>, CoreRelocError> {
+        if let Some(&composite_type) = self.pointer_types.get(&value) {
+            return Ok(Some(ResolvedAccess {
+                base: value,
+                composite_type,
+                offset_bytes: 0,
+            }));
+        }
+
+        if unsafe { LLVMIsAInstruction(value).is_null() } {
+            return Ok(None);
+        }
+
+        let opcode = unsafe { LLVMGetInstructionOpcode(value) };
+        match opcode {
+            LLVMOpcode::LLVMBitCast | LLVMOpcode::LLVMAddrSpaceCast => {
+                self.resolve_access(unsafe { LLVMGetOperand(value, 0) })
+            }
+            LLVMOpcode::LLVMGetElementPtr => {
+                let base = unsafe { LLVMGetOperand(value, 0) };
+                let Some(mut resolved) = self.resolve_access(base)? else {
+                    return Ok(None);
+                };
+                let offset = self.constant_gep_offset(value)?;
+                resolved.offset_bytes = resolved
+                    .offset_bytes
+                    .checked_add(offset)
+                    .ok_or(GepOffsetError::OffsetOverflow)?;
+                Ok(Some(resolved))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn constant_gep_offset(&self, gep: LLVMValueRef) -> Result<u64, GepOffsetError> {
+        let mut current_type = unsafe { LLVMGetGEPSourceElementType(gep) };
+        let mut offset_bytes = 0_u64;
+        let num_operands = unsafe { LLVMGetNumOperands(gep) };
+
+        for operand_index in 1..num_operands {
+            let index_operand = unsafe { LLVMGetOperand(gep, operand_index.cast_unsigned()) };
+            let index = if unsafe { LLVMIsAConstantInt(index_operand).is_null() } {
+                return Err(GepOffsetError::NonConstantIndex);
+            } else {
+                unsafe { LLVMConstIntGetZExtValue(index_operand) }
+            };
+
+            if operand_index == 1 {
+                let stride = self.data_layout.abi_size_of_type(current_type);
+                offset_bytes = offset_bytes
+                    .checked_add(
+                        index
+                            .checked_mul(stride)
+                            .ok_or(GepOffsetError::OffsetOverflow)?,
+                    )
+                    .ok_or(GepOffsetError::OffsetOverflow)?;
+                continue;
+            }
+
+            match unsafe { LLVMGetTypeKind(current_type) } {
+                LLVMTypeKind::LLVMStructTypeKind => {
+                    let field_index = index
+                        .try_into()
+                        .map_err(|_| GepOffsetError::BadStructIndex)?;
+                    let field_offset = self
+                        .data_layout
+                        .offset_of_element(current_type, field_index);
+                    offset_bytes = offset_bytes
+                        .checked_add(field_offset)
+                        .ok_or(GepOffsetError::OffsetOverflow)?;
+                    current_type = unsafe { LLVMStructGetTypeAtIndex(current_type, field_index) };
+                }
+                LLVMTypeKind::LLVMArrayTypeKind | LLVMTypeKind::LLVMVectorTypeKind => {
+                    let element_type = unsafe { LLVMGetElementType(current_type) };
+                    let stride = self.data_layout.abi_size_of_type(element_type);
+                    offset_bytes = offset_bytes
+                        .checked_add(
+                            index
+                                .checked_mul(stride)
+                                .ok_or(GepOffsetError::OffsetOverflow)?,
+                        )
+                        .ok_or(GepOffsetError::OffsetOverflow)?;
+                    current_type = element_type;
+                }
+                _ => return Err(GepOffsetError::UnsupportedTypeKind),
+            }
+        }
+
+        Ok(offset_bytes)
+    }
+
+    fn match_field(
+        &self,
+        composite_type: LLVMValueRef,
+        offset_bytes: u64,
+        expected_type: Option<llvm_sys::prelude::LLVMTypeRef>,
+    ) -> Option<FieldMatch> {
+        let composite = unsafe { DICompositeType::from_value_ref(composite_type) };
+        let offset_bits = offset_bytes.checked_mul(BITS_PER_BYTE)?;
+
+        for (index, element) in composite.elements().enumerate() {
+            let Metadata::DIDerivedType(member) = element else {
+                continue;
+            };
+
+            if member.offset_in_bits() != offset_bits {
+                continue;
+            }
+
+            if let Some(expected_type) = expected_type
+                && !self.member_matches_llvm_type(&member, expected_type)
+            {
+                continue;
+            }
+
+            return Some(FieldMatch {
+                member: member.value_ref(),
+                member_index: index.try_into().unwrap(),
+            });
+        }
+
+        None
+    }
+
+    fn member_matches_llvm_type(
+        &self,
+        member: &DIDerivedType<'_>,
+        expected_type: llvm_sys::prelude::LLVMTypeRef,
+    ) -> bool {
+        self.metadata_matches_llvm_type(member.base_type(), expected_type)
+    }
+
+    fn metadata_matches_llvm_type(
+        &self,
+        metadata: Metadata<'_>,
+        expected_type: llvm_sys::prelude::LLVMTypeRef,
+    ) -> bool {
+        match unsafe { LLVMGetTypeKind(expected_type) } {
+            LLVMTypeKind::LLVMPointerTypeKind => {
+                matches!(metadata, Metadata::DIDerivedType(ref ty) if ty.tag() == DW_TAG_pointer_type)
+            }
+            LLVMTypeKind::LLVMIntegerTypeKind => {
+                self.metadata_size_in_bits(metadata).is_some_and(|size| {
+                    size == u64::from(unsafe { LLVMGetIntTypeWidth(expected_type) })
+                })
+            }
+            _ => !matches!(
+                metadata,
+                Metadata::DIDerivedType(ref ty) if ty.tag() == DW_TAG_pointer_type
+            ),
+        }
+    }
+
+    fn member_value_composite(&self, member: &DIDerivedType<'_>) -> Option<LLVMValueRef> {
+        match member.base_type() {
+            Metadata::DICompositeType(composite) => Some(composite.value_ref()),
+            _ => None,
+        }
+    }
+
+    fn member_pointee_composite(&self, member: &DIDerivedType<'_>) -> Option<LLVMValueRef> {
+        let Metadata::DIDerivedType(pointer_type) = member.base_type() else {
+            return None;
+        };
+        if pointer_type.tag() != DW_TAG_pointer_type {
+            return None;
+        }
+
+        match pointer_type.base_type() {
+            Metadata::DICompositeType(composite) => Some(composite.value_ref()),
+            _ => None,
+        }
+    }
+
+    fn pointer_composite_from_metadata(&self, metadata: Metadata<'_>) -> Option<LLVMValueRef> {
+        let Metadata::DIDerivedType(pointer_type) = metadata else {
+            return None;
+        };
+        if pointer_type.tag() != DW_TAG_pointer_type {
+            return None;
+        }
+
+        match pointer_type.base_type() {
+            Metadata::DICompositeType(composite)
+                if self
+                    .preserve_access_types
+                    .contains(&(composite.value_ref() as usize)) =>
+            {
+                Some(composite.value_ref())
+            }
+            _ => None,
+        }
+    }
+
+    fn build_preserve_access(
+        &mut self,
+        before: LLVMValueRef,
+        base: LLVMValueRef,
+        composite_type: LLVMValueRef,
+        member_index: u32,
+    ) -> Option<CallInst<'ctx>> {
+        let composite = unsafe { DICompositeType::from_value_ref(composite_type) };
+        let field_index = unsafe {
+            LLVMConstInt(
+                LLVMInt32TypeInContext(self.context.as_mut_ptr()),
+                member_index.into(),
+                0,
+            )
+        };
+
+        let mut call = if composite.tag() == DW_TAG_union_type {
+            let callee = self.preserve_union_access_function(base);
+            let mut args = [base, field_index];
+            self.builder.position_before(before);
+            self.builder.build_call2(callee, &mut args)
+        } else {
+            let callee = self.preserve_struct_access_function(base);
+            let element_type = self.synthetic_struct_type(composite_type)?;
+            let mut args = [base, field_index, field_index];
+            self.builder.position_before(before);
+            let mut call = self.builder.build_call2(callee, &mut args);
+            let elementtype_attr = unsafe {
+                LLVMCreateTypeAttribute(
+                    self.context.as_mut_ptr(),
+                    self.elementtype_attr_kind,
+                    element_type,
+                )
+            };
+            call.add_attribute(1, elementtype_attr);
+            call
+        };
+        call.set_metadata(self.preserve_access_md_kind, composite_type);
+        Some(call)
+    }
+
+    fn build_preserve_array_access(
+        &mut self,
+        before: LLVMValueRef,
+        base: LLVMValueRef,
+        composite_type: &DICompositeType<'_>,
+        index: u32,
+    ) -> Option<CallInst<'ctx>> {
+        let callee = self.preserve_array_access_function(base);
+        let element_type = self.synthetic_llvm_type(composite_type.base_type()?)?;
+        let dimension =
+            unsafe { LLVMConstInt(LLVMInt32TypeInContext(self.context.as_mut_ptr()), 1, 0) };
+        let last_index = unsafe {
+            LLVMConstInt(
+                LLVMInt32TypeInContext(self.context.as_mut_ptr()),
+                index.into(),
+                0,
+            )
+        };
+        let mut args = [base, dimension, last_index];
+
+        self.builder.position_before(before);
+        let mut call = self.builder.build_call2(callee, &mut args);
+        let elementtype_attr = self
+            .context
+            .create_type_attribute(self.elementtype_attr_kind, element_type);
+        call.add_attribute(1, elementtype_attr);
+        call.set_metadata(self.preserve_access_md_kind, composite_type.value_ref());
+        Some(call)
+    }
+
+    fn preserve_array_access_function(&self, base: LLVMValueRef) -> LLVMValueRef {
+        let ptr_ty = unsafe { LLVMTypeOf(base) };
+        let mut overloaded_tys = [ptr_ty, ptr_ty];
+        let intrinsic_id = unsafe {
+            LLVMLookupIntrinsicID(
+                PRESERVE_ARRAY_ACCESS_INTRINSIC_NAME.as_ptr(),
+                PRESERVE_ARRAY_ACCESS_INTRINSIC_NAME.to_bytes().len(),
+            )
+        };
+
+        unsafe {
+            LLVMGetIntrinsicDeclaration(
+                self.module.as_mut_ptr(),
+                intrinsic_id,
+                overloaded_tys.as_mut_ptr(),
+                overloaded_tys.len(),
+            )
+        }
+    }
+
+    fn preserve_struct_access_function(&self, base: LLVMValueRef) -> LLVMValueRef {
+        let ptr_ty = unsafe { LLVMTypeOf(base) };
+        let mut overloaded_tys = [ptr_ty, ptr_ty];
+        let intrinsic_id = unsafe {
+            LLVMLookupIntrinsicID(
+                PRESERVE_STRUCT_ACCESS_INTRINSIC_NAME.as_ptr(),
+                PRESERVE_STRUCT_ACCESS_INTRINSIC_NAME.to_bytes().len(),
+            )
+        };
+
+        unsafe {
+            LLVMGetIntrinsicDeclaration(
+                self.module.as_mut_ptr(),
+                intrinsic_id,
+                overloaded_tys.as_mut_ptr(),
+                overloaded_tys.len(),
+            )
+        }
+    }
+
+    fn preserve_union_access_function(&self, base: LLVMValueRef) -> LLVMValueRef {
+        let ptr_ty = unsafe { LLVMTypeOf(base) };
+        let mut overloaded_tys = [ptr_ty, ptr_ty];
+        let intrinsic_id = unsafe {
+            LLVMLookupIntrinsicID(
+                PRESERVE_UNION_ACCESS_INTRINSIC_NAME.as_ptr(),
+                PRESERVE_UNION_ACCESS_INTRINSIC_NAME.to_bytes().len(),
+            )
+        };
+
+        unsafe {
+            LLVMGetIntrinsicDeclaration(
+                self.module.as_mut_ptr(),
+                intrinsic_id,
+                overloaded_tys.as_mut_ptr(),
+                overloaded_tys.len(),
+            )
+        }
+    }
+
+    fn is_pointer_type(&self, ty: llvm_sys::prelude::LLVMTypeRef) -> bool {
+        matches!(
+            unsafe { LLVMGetTypeKind(ty) },
+            LLVMTypeKind::LLVMPointerTypeKind
+        )
+    }
+
+    fn synthetic_struct_type(
+        &mut self,
+        composite_type: LLVMValueRef,
+    ) -> Option<llvm_sys::prelude::LLVMTypeRef> {
+        if let Some(&ty) = self.synthetic_types.get(&composite_type) {
+            return Some(ty);
+        }
+
+        let composite = unsafe { DICompositeType::from_value_ref(composite_type) };
+        let mut element_types = Vec::new();
+        for element in composite.elements() {
+            let Metadata::DIDerivedType(member) = element else {
+                continue;
+            };
+            let element_type = self.synthetic_llvm_type(member.base_type())?;
+            element_types.push(element_type);
+        }
+
+        let ty = unsafe {
+            LLVMStructTypeInContext(
+                self.context.as_mut_ptr(),
+                element_types.as_mut_ptr(),
+                element_types.len().try_into().unwrap(),
+                0,
+            )
+        };
+        let _prev = self.synthetic_types.insert(composite_type, ty);
+        Some(ty)
+    }
+
+    fn synthetic_array_type(
+        &mut self,
+        composite_type: LLVMValueRef,
+    ) -> Option<llvm_sys::prelude::LLVMTypeRef> {
+        if let Some(&ty) = self.synthetic_types.get(&composite_type) {
+            return Some(ty);
+        }
+
+        let composite = unsafe { DICompositeType::from_value_ref(composite_type) };
+        let element_type = self.synthetic_llvm_type(composite.base_type()?)?;
+        let base_size_bits = self.metadata_size_in_bits(composite.base_type()?)?;
+        if base_size_bits == 0 {
+            return None;
+        }
+        let element_count = composite.size_in_bits().checked_div(base_size_bits)?;
+        let ty = unsafe { LLVMArrayType2(element_type, element_count) };
+        let _prev = self.synthetic_types.insert(composite_type, ty);
+        Some(ty)
+    }
+
+    fn synthetic_llvm_type(
+        &mut self,
+        metadata: Metadata<'_>,
+    ) -> Option<llvm_sys::prelude::LLVMTypeRef> {
+        match metadata {
+            Metadata::DIDerivedType(derived) if derived.tag() == DW_TAG_pointer_type => {
+                Some(unsafe {
+                    LLVMPointerType(LLVMInt8TypeInContext(self.context.as_mut_ptr()), 0)
+                })
+            }
+            Metadata::DICompositeType(composite) => {
+                if composite.tag() == DW_TAG_array_type {
+                    self.synthetic_array_type(composite.value_ref())
+                } else {
+                    self.synthetic_struct_type(composite.value_ref())
+                }
+            }
+            Metadata::Other(value_ref) => {
+                let metadata_ref = unsafe { llvm_sys::core::LLVMValueAsMetadata(value_ref) };
+                match unsafe { LLVMGetMetadataKind(metadata_ref) } {
+                    LLVMMetadataKind::LLVMDIBasicTypeMetadataKind => {
+                        let size_bits = unsafe { LLVMDITypeGetSizeInBits(metadata_ref) };
+                        Some(unsafe {
+                            LLVMIntTypeInContext(
+                                self.context.as_mut_ptr(),
+                                size_bits.try_into().unwrap(),
+                            )
+                        })
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn array_element_composite(&self, composite: &DICompositeType<'_>) -> Option<LLVMValueRef> {
+        match composite.base_type()? {
+            Metadata::DICompositeType(element) => Some(element.value_ref()),
+            _ => None,
+        }
+    }
+
+    fn build_access_path(
+        &mut self,
+        before: LLVMValueRef,
+        base: LLVMValueRef,
+        composite_type: LLVMValueRef,
+        offset_bytes: u64,
+        expected_type: Option<llvm_sys::prelude::LLVMTypeRef>,
+    ) -> Result<Option<AccessPath>, CoreRelocError> {
+        let composite = unsafe { DICompositeType::from_value_ref(composite_type) };
+        if composite.tag() == DW_TAG_array_type {
+            return self.build_array_access_path(
+                before,
+                base,
+                &composite,
+                offset_bytes,
+                expected_type,
+            );
+        }
+
+        if let Some(field) = self.match_field(composite_type, offset_bytes, expected_type) {
+            let ptr = match self.build_preserve_access(
+                before,
+                base,
+                composite_type,
+                field.member_index,
+            ) {
+                Some(ptr) => ptr,
+                None => return Ok(None),
+            };
+            let member = unsafe { DIDerivedType::from_value_ref(field.member) };
+            let nested_composite = if expected_type.is_some_and(|ty| self.is_pointer_type(ty)) {
+                self.member_pointee_composite(&member)
+            } else {
+                self.member_value_composite(&member)
+            };
+            return Ok(Some(AccessPath {
+                ptr: ptr.value_ref(),
+                nested_composite,
+            }));
+        }
+
+        let Some(containing) = self.match_containing_member(composite_type, offset_bytes) else {
+            return Ok(None);
+        };
+        let ptr =
+            match self.build_preserve_access(before, base, composite_type, containing.member_index)
+            {
+                Some(ptr) => ptr,
+                None => return Ok(None),
+            };
+        self.build_access_path(
+            before,
+            ptr.value_ref(),
+            containing.nested_composite,
+            containing.remainder_bytes,
+            expected_type,
+        )
+    }
+
+    fn build_array_access_path(
+        &mut self,
+        before: LLVMValueRef,
+        base: LLVMValueRef,
+        composite: &DICompositeType<'_>,
+        offset_bytes: u64,
+        expected_type: Option<llvm_sys::prelude::LLVMTypeRef>,
+    ) -> Result<Option<AccessPath>, CoreRelocError> {
+        let element_size_bits = self
+            .metadata_size_in_bits(
+                composite
+                    .base_type()
+                    .ok_or(ArrayAccessError::MissingElementType)?,
+            )
+            .ok_or(ArrayAccessError::MissingElementType)?;
+        if element_size_bits % BITS_PER_BYTE != 0 {
+            return Err(ArrayAccessError::NonByteAlignedElementSize.into());
+        }
+        let element_size_bytes = element_size_bits / BITS_PER_BYTE;
+        if element_size_bytes == 0 {
+            return Err(ArrayAccessError::ZeroSizedElement.into());
+        }
+
+        let index = offset_bytes / element_size_bytes;
+        let remainder_bytes = offset_bytes % element_size_bytes;
+        let index: u32 = index
+            .try_into()
+            .map_err(|_| ArrayAccessError::IndexOverflow)?;
+        let Some(call) = self.build_preserve_array_access(before, base, composite, index) else {
+            return Ok(None);
+        };
+        let call_value = call.value_ref();
+
+        if remainder_bytes == 0 {
+            if let Some(expected_type) = expected_type
+                && !self.metadata_matches_llvm_type(
+                    composite
+                        .base_type()
+                        .ok_or(ArrayAccessError::MissingElementType)?,
+                    expected_type,
+                )
+            {
+                return Ok(None);
+            }
+
+            return Ok(Some(AccessPath {
+                ptr: call_value,
+                nested_composite: self.array_element_composite(composite),
+            }));
+        }
+
+        let Some(nested) = self.array_element_composite(composite) else {
+            return Ok(None);
+        };
+        self.build_access_path(before, call_value, nested, remainder_bytes, expected_type)
+    }
+
+    fn match_containing_member(
+        &self,
+        composite_type: LLVMValueRef,
+        offset_bytes: u64,
+    ) -> Option<ContainingMemberMatch> {
+        let composite = unsafe { DICompositeType::from_value_ref(composite_type) };
+        let offset_bits = offset_bytes.checked_mul(BITS_PER_BYTE)?;
+
+        for (index, element) in composite.elements().enumerate() {
+            let Metadata::DIDerivedType(member) = element else {
+                continue;
+            };
+            let member_offset_bits = member.offset_in_bits();
+            if offset_bits < member_offset_bits {
+                continue;
+            }
+
+            let Metadata::DICompositeType(nested) = member.base_type() else {
+                continue;
+            };
+            let nested_size_bits = nested.size_in_bits();
+            if offset_bits >= member_offset_bits.checked_add(nested_size_bits)? {
+                continue;
+            }
+
+            return Some(ContainingMemberMatch {
+                member_index: index.try_into().unwrap(),
+                nested_composite: nested.value_ref(),
+                remainder_bytes: (offset_bits - member_offset_bits) / BITS_PER_BYTE,
+            });
+        }
+
+        None
+    }
+
+    fn metadata_size_in_bits(&self, metadata: Metadata<'_>) -> Option<u64> {
+        match metadata {
+            Metadata::DIDerivedType(derived) => Some(derived.size_in_bits()),
+            Metadata::DICompositeType(composite) => Some(composite.size_in_bits()),
+            Metadata::Other(value_ref) => {
+                let metadata_ref = unsafe { llvm_sys::core::LLVMValueAsMetadata(value_ref) };
+                matches!(
+                    unsafe { LLVMGetMetadataKind(metadata_ref) },
+                    LLVMMetadataKind::LLVMDIBasicTypeMetadataKind
+                )
+                .then(|| unsafe { LLVMDITypeGetSizeInBits(metadata_ref) })
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -13,7 +13,7 @@ use super::types::{
     di::DIType,
     ir::{Function, MDNode, Metadata, Value},
 };
-use crate::llvm::{DIBuilder, LLVMContext, LLVMModule, iter::*, types::di::DISubprogram};
+use crate::llvm::{DIBuilder, LLVMContext, LLVMModule, types::di::DISubprogram};
 
 // KSYM_NAME_LEN from linux kernel intentionally set
 // to lower value found across kernel versions to ensure
@@ -224,7 +224,7 @@ impl<'ctx> DISanitizer<'ctx> {
             }
 
             for basic_block in fun.basic_blocks() {
-                for instruction in basic_block.instructions_iter() {
+                for instruction in basic_block.instructions() {
                     self.visit_item(Item::Instruction(instruction));
                 }
             }

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -27,7 +27,12 @@ pub(crate) struct DISanitizer<'ctx> {
     visited_nodes: HashSet<u64>,
     replace_subprograms: HashMap<u64, DISubprogram<'ctx>>,
     skipped_types_lossy: Vec<String>,
+    preserve_access_types: HashSet<usize>,
 }
+
+/// The marker type name that opts a composite type into CO-RE/BTF relocation
+/// emission when it appears as one of the type's fields.
+const RELOCATABLE_MARKER_TYPE: &[u8] = b"Relocatable";
 
 // Sanitize Rust type names to be valid C type names.
 fn sanitize_type_name(name: &[u8]) -> Vec<u8> {
@@ -63,6 +68,7 @@ impl<'ctx> DISanitizer<'ctx> {
             visited_nodes: HashSet::new(),
             replace_subprograms: HashMap::new(),
             skipped_types_lossy: Vec::new(),
+            preserve_access_types: HashSet::new(),
         }
     }
 
@@ -118,7 +124,29 @@ impl<'ctx> DISanitizer<'ctx> {
                                     }
                                 }
                                 Metadata::DIDerivedType(di_derived_type) => {
-                                    members.push(di_derived_type.into());
+                                    let base_type = di_derived_type.base_type();
+
+                                    match base_type {
+                                        Metadata::DICompositeType(base_type_di_composite_type) => {
+                                            if let Some(base_type_name) =
+                                                base_type_di_composite_type.name()
+                                            {
+                                                if base_type_name == RELOCATABLE_MARKER_TYPE {
+                                                    let _is_new =
+                                                        self.preserve_access_types
+                                                            .insert(di_composite_type.value_ref()
+                                                                as usize);
+                                                } else {
+                                                    members.push(di_derived_type.into());
+                                                }
+                                            } else {
+                                                members.push(di_derived_type.into());
+                                            }
+                                        }
+                                        _ => {
+                                            members.push(di_derived_type.into());
+                                        }
+                                    }
                                 }
                                 _ => {}
                             }
@@ -225,13 +253,13 @@ impl<'ctx> DISanitizer<'ctx> {
 
             for basic_block in fun.basic_blocks() {
                 for instruction in basic_block.instructions() {
-                    self.visit_item(Item::Instruction(instruction));
+                    self.visit_item(Item::Instruction(instruction.value_ref()));
                 }
             }
         }
     }
 
-    pub(crate) fn run(mut self, exported_symbols: &HashSet<Cow<'_, [u8]>>) {
+    pub(crate) fn run(mut self, exported_symbols: &HashSet<Cow<'_, [u8]>>) -> HashSet<usize> {
         let module = self.module;
 
         self.replace_subprograms = self.fix_subprogram_linkage(exported_symbols);
@@ -253,6 +281,8 @@ impl<'ctx> DISanitizer<'ctx> {
                 self.skipped_types_lossy.join(", ")
             );
         }
+
+        self.preserve_access_types.clone()
     }
 
     // Make it so that only exported symbols (programs marked as #[no_mangle]) get BTF

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -3,7 +3,6 @@ use std::{
     collections::{HashMap, HashSet, hash_map::DefaultHasher},
     hash::Hasher as _,
     io::Write as _,
-    ptr,
 };
 
 use gimli::{DW_TAG_pointer_type, DW_TAG_structure_type, DW_TAG_union_type, DW_TAG_variant_part};
@@ -323,15 +322,14 @@ impl<'ctx> DISanitizer<'ctx> {
             // variables, including function arguments which otherwise become "anon". See
             // LLVMDIBuilderFinalizeSubprogram and DISubprogram::replaceRetainedNodes.
             if let Some(retained_nodes) = subprogram.retained_nodes() {
-                new_program.set_retained_nodes(retained_nodes);
+                new_program.set_retained_nodes(&retained_nodes);
             }
 
             // Remove retained nodes from the old program or we'll hit a debug assertion since
             // its debug variables no longer point to the program. See the
             // NumAbstractSubprograms assertion in DwarfDebug::endFunctionImpl in LLVM.
-            let empty_node =
-                unsafe { LLVMMDNodeInContext2(self.context.as_mut_ptr(), ptr::null_mut(), 0) };
-            subprogram.set_retained_nodes(empty_node);
+            let empty_node = MDNode::empty(self.context);
+            subprogram.set_retained_nodes(&empty_node);
 
             assert_eq!(
                 replace.insert(subprogram.value_ref as u64, unsafe {

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -212,10 +212,10 @@ impl<'ctx> DISanitizer<'ctx> {
         }
 
         if let Some(entries) = value.metadata_entries() {
-            for (index, (metadata, kind)) in entries.iter().enumerate() {
+            for (metadata, _) in entries.iter() {
                 let metadata_value =
                     unsafe { LLVMMetadataAsValue(self.context.as_mut_ptr(), metadata) };
-                self.visit_item(Item::MetadataEntry(metadata_value, kind, index));
+                self.visit_item(Item::MetadataEntry(metadata_value));
             }
         }
 
@@ -349,7 +349,7 @@ impl<'ctx> DISanitizer<'ctx> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 enum Item {
     GlobalVariable(LLVMValueRef),
     GlobalAlias(LLVMValueRef),
@@ -357,7 +357,7 @@ enum Item {
     FunctionParam(LLVMValueRef),
     Instruction(LLVMValueRef),
     Operand(Operand),
-    MetadataEntry(LLVMValueRef, u32, usize),
+    MetadataEntry(LLVMValueRef),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -394,7 +394,7 @@ impl Item {
             | Self::FunctionParam(value)
             | Self::Instruction(value)
             | Self::Operand(Operand { value, .. })
-            | Self::MetadataEntry(value, _, _) => *value,
+            | Self::MetadataEntry(value) => *value,
         }
     }
 

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -163,7 +163,7 @@ impl<'ctx> DISanitizer<'ctx> {
     }
 
     // navigate the tree of LLVMValueRefs (DFS-pre-order)
-    fn visit_item(&mut self, mut item: Item) {
+    fn visit_item(&mut self, mut item: Item<'_>) {
         let value_ref = item.value_ref();
         let value_id = item.value_id();
 
@@ -277,11 +277,7 @@ impl<'ctx> DISanitizer<'ctx> {
     ) -> HashMap<u64, LLVMMetadataRef> {
         let mut replace = HashMap::new();
 
-        for mut function in self
-            .module
-            .functions()
-            .map(|value| unsafe { Function::from_value_ref(value) })
-        {
+        for mut function in self.module.functions() {
             if export_symbols.contains(function.name()) {
                 continue;
             }
@@ -350,10 +346,10 @@ impl<'ctx> DISanitizer<'ctx> {
 }
 
 #[derive(Clone, Debug)]
-enum Item {
+enum Item<'ctx> {
     GlobalVariable(LLVMValueRef),
     GlobalAlias(LLVMValueRef),
-    Function(LLVMValueRef),
+    Function(Function<'ctx>),
     FunctionParam(LLVMValueRef),
     Instruction(LLVMValueRef),
     Operand(Operand),
@@ -385,16 +381,16 @@ impl Operand {
     }
 }
 
-impl Item {
+impl Item<'_> {
     fn value_ref(&self) -> LLVMValueRef {
         match self {
             Self::GlobalVariable(value)
             | Self::GlobalAlias(value)
-            | Self::Function(value)
             | Self::FunctionParam(value)
             | Self::Instruction(value)
             | Self::Operand(Operand { value, .. })
             | Self::MetadataEntry(value) => *value,
+            Self::Function(function) => function.value_ref,
         }
     }
 

--- a/src/llvm/di.rs
+++ b/src/llvm/di.rs
@@ -13,7 +13,7 @@ use super::types::{
     di::DIType,
     ir::{Function, MDNode, Metadata, Value},
 };
-use crate::llvm::{DIBuilder, LLVMContext, LLVMModule, iter::*};
+use crate::llvm::{DIBuilder, LLVMContext, LLVMModule, iter::*, types::di::DISubprogram};
 
 // KSYM_NAME_LEN from linux kernel intentionally set
 // to lower value found across kernel versions to ensure
@@ -25,7 +25,7 @@ pub(crate) struct DISanitizer<'ctx> {
     module: &'ctx LLVMModule<'ctx>,
     builder: DIBuilder<'ctx>,
     visited_nodes: HashSet<u64>,
-    replace_operands: HashMap<u64, LLVMMetadataRef>,
+    replace_subprograms: HashMap<u64, DISubprogram<'ctx>>,
     skipped_types_lossy: Vec<String>,
 }
 
@@ -61,7 +61,7 @@ impl<'ctx> DISanitizer<'ctx> {
             module,
             builder: DIBuilder::new(module),
             visited_nodes: HashSet::new(),
-            replace_operands: HashMap::new(),
+            replace_subprograms: HashMap::new(),
             skipped_types_lossy: Vec::new(),
         }
     }
@@ -183,10 +183,8 @@ impl<'ctx> DISanitizer<'ctx> {
             // When we have an operand to replace, we must do so regardless of whether we've already
             // seen its value or not, since the same value can appear as an operand in multiple
             // nodes in the tree.
-            if let Some(new_metadata) = self.replace_operands.get(&value_id) {
-                operand.replace(unsafe {
-                    LLVMMetadataAsValue(self.context.as_mut_ptr(), *new_metadata)
-                })
+            if let Some(new_subprogram) = self.replace_subprograms.get(&value_id) {
+                operand.replace(new_subprogram.value_ref);
             }
         }
 
@@ -236,7 +234,7 @@ impl<'ctx> DISanitizer<'ctx> {
     pub(crate) fn run(mut self, exported_symbols: &HashSet<Cow<'_, [u8]>>) {
         let module = self.module;
 
-        self.replace_operands = self.fix_subprogram_linkage(exported_symbols);
+        self.replace_subprograms = self.fix_subprogram_linkage(exported_symbols);
 
         for value in module.globals() {
             self.visit_item(Item::GlobalVariable(value));
@@ -273,7 +271,7 @@ impl<'ctx> DISanitizer<'ctx> {
     fn fix_subprogram_linkage(
         &mut self,
         export_symbols: &HashSet<Cow<'_, [u8]>>,
-    ) -> HashMap<u64, LLVMMetadataRef> {
+    ) -> HashMap<u64, DISubprogram<'ctx>> {
         let mut replace = HashMap::new();
 
         for mut function in self.module.functions() {
@@ -331,11 +329,10 @@ impl<'ctx> DISanitizer<'ctx> {
             let empty_node = MDNode::empty(self.context);
             subprogram.set_retained_nodes(&empty_node);
 
-            assert_eq!(
-                replace.insert(subprogram.value_ref as u64, unsafe {
-                    LLVMValueAsMetadata(new_program.value_ref)
-                }),
-                None
+            assert!(
+                replace
+                    .insert(subprogram.value_ref as u64, new_program)
+                    .is_none()
             );
         }
 

--- a/src/llvm/iter.rs
+++ b/src/llvm/iter.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use llvm_sys::{
     core::{
         LLVMGetFirstBasicBlock, LLVMGetFirstFunction, LLVMGetFirstGlobal, LLVMGetFirstGlobalAlias,
@@ -9,41 +7,37 @@ use llvm_sys::{
     },
     prelude::{LLVMBasicBlockRef, LLVMModuleRef, LLVMValueRef},
 };
+#[cfg(feature = "llvm-22")]
+use llvm_sys::{
+    core::{LLVMGetFirstDbgRecord, LLVMGetLastDbgRecord, LLVMGetNextDbgRecord},
+    prelude::LLVMDbgRecordRef,
+};
 
 macro_rules! llvm_iterator {
     ($trait_name:ident, $iterator_name:ident, $iterable:ty, $method_name:ident, $item_ty:ty, $first:expr, $last:expr, $next:expr $(,)?) => {
         pub(crate) trait $trait_name {
-            fn $method_name(&self) -> $iterator_name<'_>;
+            fn $method_name(&self) -> $iterator_name;
         }
 
-        pub(crate) struct $iterator_name<'a> {
-            lifetime: PhantomData<&'a $iterable>,
+        pub(crate) struct $iterator_name {
             next: $item_ty,
             last: $item_ty,
         }
 
         impl $trait_name for $iterable {
-            fn $method_name(&self) -> $iterator_name<'_> {
+            fn $method_name(&self) -> $iterator_name {
                 let first = unsafe { $first(*self) };
                 let last = unsafe { $last(*self) };
                 assert_eq!(first.is_null(), last.is_null());
-                $iterator_name {
-                    lifetime: PhantomData,
-                    next: first,
-                    last,
-                }
+                $iterator_name { next: first, last }
             }
         }
 
-        impl Iterator for $iterator_name<'_> {
+        impl Iterator for $iterator_name {
             type Item = $item_ty;
 
             fn next(&mut self) -> Option<Self::Item> {
-                let Self {
-                    lifetime: _,
-                    next,
-                    last,
-                } = self;
+                let Self { next, last } = self;
                 if next.is_null() {
                     return None;
                 }
@@ -110,4 +104,16 @@ llvm_iterator!(
     LLVMGetFirstInstruction,
     LLVMGetLastInstruction,
     LLVMGetNextInstruction
+);
+
+#[cfg(feature = "llvm-22")]
+llvm_iterator!(
+    IterDbgRecords,
+    DbgRecordsIter,
+    LLVMValueRef,
+    dbg_records_iter,
+    LLVMDbgRecordRef,
+    LLVMGetFirstDbgRecord,
+    LLVMGetLastDbgRecord,
+    LLVMGetNextDbgRecord,
 );

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -1,3 +1,8 @@
+// CO-RE relocations rely on debug info record API that was introduced in LLVM
+// 22:
+// https://llvm.org/docs/RemoveDIsDebugInfo.html
+#[cfg(feature = "llvm-22")]
+mod core_reloc;
 mod di;
 mod iter;
 mod types;
@@ -10,6 +15,8 @@ use std::{
     ptr, slice, str,
 };
 
+#[cfg(feature = "llvm-22")]
+pub(crate) use core_reloc::{CoreRelocError, CoreRelocPass};
 pub(crate) use di::DISanitizer;
 use iter::{IterModuleFunctions as _, IterModuleGlobalAliases as _, IterModuleGlobals as _};
 use llvm_sys::{
@@ -50,6 +57,8 @@ pub(crate) use types::{
     module::LLVMModule,
     target_machine::LLVMTargetMachine,
 };
+#[cfg(feature = "llvm-22")]
+pub(crate) use types::{data_layout::DataLayout, ir_builder::IRBuilder};
 
 use crate::OptLevel;
 

--- a/src/llvm/types/context.rs
+++ b/src/llvm/types/context.rs
@@ -14,6 +14,11 @@ use llvm_sys::{
     },
     prelude::{LLVMContextRef, LLVMDiagnosticInfoRef},
 };
+#[cfg(feature = "llvm-22")]
+use llvm_sys::{
+    core::{LLVMCreateTypeAttribute, LLVMGetMDKindIDInContext},
+    prelude::{LLVMAttributeRef, LLVMTypeRef},
+};
 
 use crate::llvm::{LLVMDiagnosticHandler, Message, types::module::LLVMModule};
 
@@ -60,6 +65,15 @@ impl LLVMContext {
         })
     }
 
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn create_type_attribute(
+        &self,
+        kind: u32,
+        type_ref: LLVMTypeRef,
+    ) -> LLVMAttributeRef {
+        unsafe { LLVMCreateTypeAttribute(self.as_mut_ptr(), kind, type_ref) }
+    }
+
     /// Install a context-local diagnostic handler.
     pub(crate) fn set_diagnostic_handler<T>(&mut self, handler: T) -> InstalledDiagnosticHandler<T>
     where
@@ -95,6 +109,17 @@ impl LLVMContext {
         // deal with an Option. It also contributes to keeping the handler alive
         // for as long as the handle (or the context-held clone) exists.
         InstalledDiagnosticHandler { inner: pinrc }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn md_kind_id(&self, name: &CStr) -> u32 {
+        unsafe {
+            LLVMGetMDKindIDInContext(
+                self.as_mut_ptr(),
+                name.as_ptr(),
+                name.to_bytes().len().try_into().unwrap(),
+            )
+        }
     }
 }
 

--- a/src/llvm/types/data_layout.rs
+++ b/src/llvm/types/data_layout.rs
@@ -1,0 +1,28 @@
+use std::marker::PhantomData;
+
+use llvm_sys::{
+    prelude::LLVMTypeRef,
+    target::{LLVMABISizeOfType, LLVMOffsetOfElement, LLVMTargetDataRef},
+};
+
+pub(crate) struct DataLayout<'ctx> {
+    data_layout: LLVMTargetDataRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+impl DataLayout<'_> {
+    pub(in crate::llvm) unsafe fn from_ref(data_layout: LLVMTargetDataRef) -> Self {
+        Self {
+            data_layout,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn abi_size_of_type(&self, ty: LLVMTypeRef) -> u64 {
+        unsafe { LLVMABISizeOfType(self.data_layout, ty) }
+    }
+
+    pub(crate) fn offset_of_element(&self, struct_ty: LLVMTypeRef, element: u32) -> u64 {
+        unsafe { LLVMOffsetOfElement(self.data_layout, struct_ty, element) }
+    }
+}

--- a/src/llvm/types/di.rs
+++ b/src/llvm/types/di.rs
@@ -416,19 +416,19 @@ impl DISubprogram<'_> {
         };
     }
 
-    pub(crate) fn retained_nodes(&self) -> Option<LLVMMetadataRef> {
+    pub(crate) fn retained_nodes(&self) -> Option<MDNode<'_>> {
         unsafe {
             let nodes = LLVMGetOperand(self.value_ref, DISubprogramOperand::RetainedNodes as u32);
-            (!nodes.is_null()).then(|| LLVMValueAsMetadata(nodes))
+            (!nodes.is_null()).then(|| MDNode::from_value_ref(nodes))
         }
     }
 
-    pub(crate) fn set_retained_nodes(&mut self, nodes: LLVMMetadataRef) {
+    pub(crate) fn set_retained_nodes(&mut self, nodes: &MDNode<'_>) {
         unsafe {
             LLVMReplaceMDNodeOperandWith(
                 self.value_ref,
                 DISubprogramOperand::RetainedNodes as u32,
-                nodes,
+                LLVMValueAsMetadata(nodes.value_ref),
             )
         };
     }

--- a/src/llvm/types/di.rs
+++ b/src/llvm/types/di.rs
@@ -1,6 +1,8 @@
 use std::{marker::PhantomData, slice};
 
 use gimli::DwTag;
+#[cfg(feature = "llvm-22")]
+use llvm_sys::prelude::LLVMContextRef;
 use llvm_sys::{
     core::{LLVMGetNumOperands, LLVMGetOperand, LLVMReplaceMDNodeOperandWith, LLVMValueAsMetadata},
     debuginfo::{
@@ -146,6 +148,22 @@ impl<'ctx> From<DIDerivedType<'ctx>> for DIType<'ctx> {
     }
 }
 
+/// Represents the operands for a [`DIDerivedType`]. The enum values correspond
+/// to the operand indices within metadata nodes.
+#[repr(u32)]
+enum DIDerivedTypeOperand {
+    /// [`DIType`] representing a base type of the given derived type.
+    /// Reference in [LLVM 20][llvm-20] and [LLVM 21][llvm-21].
+    ///
+    /// [llvm-20]: https://github.com/llvm/llvm-project/blob/llvmorg-20.1.8/llvm/include/llvm/IR/DebugInfoMetadata.h#L1106
+    /// [llvm-21]: https://github.com/llvm/llvm-project/blob/llvmorg-21.1.0-rc3/llvm/include/llvm/IR/DebugInfoMetadata.h#L1386
+    ///
+    #[cfg(feature = "llvm-20")]
+    BaseType = 3,
+    #[cfg(not(feature = "llvm-20"))]
+    BaseType = 5,
+}
+
 /// Represents the debug information for a derived type in LLVM IR.
 ///
 /// The types derived from other types usually add a level of indirection or an
@@ -175,6 +193,14 @@ impl DIDerivedType<'_> {
         }
     }
 
+    /// Returns the base type of this derived type.
+    pub(crate) fn base_type(&self) -> Metadata<'_> {
+        unsafe {
+            let value = LLVMGetOperand(self.value_ref, DIDerivedTypeOperand::BaseType as u32);
+            Metadata::from_value_ref(value)
+        }
+    }
+
     /// Replaces the name of the type with a new name.
     ///
     /// # Errors
@@ -194,12 +220,31 @@ impl DIDerivedType<'_> {
     pub(crate) fn tag(&self) -> DwTag {
         unsafe { di_node_tag(self.metadata_ref) }
     }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn offset_in_bits(&self) -> u64 {
+        unsafe { LLVMDITypeGetOffsetInBits(self.metadata_ref) }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn size_in_bits(&self) -> u64 {
+        unsafe { llvm_sys::debuginfo::LLVMDITypeGetSizeInBits(self.metadata_ref) }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) const fn value_ref(&self) -> LLVMValueRef {
+        self.value_ref
+    }
 }
 
 /// Represents the operands for a [`DICompositeType`]. The enum values
 /// correspond to the operand indices within metadata nodes.
 #[repr(u32)]
 enum DICompositeTypeOperand {
+    #[cfg(all(feature = "llvm-20", feature = "llvm-22"))]
+    BaseType = 3,
+    #[cfg(all(not(feature = "llvm-20"), feature = "llvm-22"))]
+    BaseType = 5,
     /// Elements of the composite type. Reference in [LLVM 20][llvm-20] and
     /// [LLVM 21][llvm-21].
     ///
@@ -255,6 +300,13 @@ impl DICompositeType<'_> {
         })
     }
 
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn base_type(&self) -> Option<Metadata<'_>> {
+        let operand =
+            unsafe { LLVMGetOperand(self.value_ref, DICompositeTypeOperand::BaseType as u32) };
+        (!operand.is_null()).then(|| unsafe { Metadata::from_value_ref(operand) })
+    }
+
     /// Returns the name of the composite type.
     pub(crate) fn name(&self) -> Option<&[u8]> {
         unsafe { di_type_name(self.metadata_ref) }
@@ -276,6 +328,11 @@ impl DICompositeType<'_> {
     /// Returns the line number in the source code where the type is defined.
     pub(crate) fn line(&self) -> u32 {
         unsafe { LLVMDITypeGetLine(self.metadata_ref) }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn size_in_bits(&self) -> u64 {
+        unsafe { llvm_sys::debuginfo::LLVMDITypeGetSizeInBits(self.metadata_ref) }
     }
 
     /// Replaces the elements of the composite type with a new metadata node.
@@ -310,6 +367,45 @@ impl DICompositeType<'_> {
     /// Returns a DWARF tag of the given composite type.
     pub(crate) fn tag(&self) -> DwTag {
         unsafe { di_node_tag(self.metadata_ref) }
+    }
+
+    pub(crate) const fn value_ref(&self) -> LLVMValueRef {
+        self.value_ref
+    }
+}
+
+#[cfg(feature = "llvm-22")]
+pub(crate) struct DISubroutineType<'ctx> {
+    value_ref: LLVMValueRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+#[cfg(feature = "llvm-22")]
+impl DISubroutineType<'_> {
+    const TYPE_ARRAY_OPERAND: u32 = 5;
+
+    pub(crate) unsafe fn from_metadata_ref(
+        context: LLVMContextRef,
+        metadata_ref: LLVMMetadataRef,
+    ) -> Self {
+        Self {
+            value_ref: unsafe { llvm_sys::core::LLVMMetadataAsValue(context, metadata_ref) },
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn type_array(&self) -> impl Iterator<Item = Option<Metadata<'_>>> {
+        let type_array = unsafe { LLVMGetOperand(self.value_ref, Self::TYPE_ARRAY_OPERAND) };
+        let operands = if type_array.is_null() {
+            0
+        } else {
+            unsafe { LLVMGetNumOperands(type_array) }
+        };
+
+        (0..operands).map(move |i| {
+            let operand = unsafe { LLVMGetOperand(type_array, i.cast_unsigned()) };
+            (!operand.is_null()).then(|| unsafe { Metadata::from_value_ref(operand) })
+        })
     }
 }
 

--- a/src/llvm/types/instruction.rs
+++ b/src/llvm/types/instruction.rs
@@ -1,0 +1,229 @@
+use std::marker::PhantomData;
+
+use llvm_sys::{LLVMOpcode, core::LLVMGetInstructionOpcode, prelude::LLVMValueRef};
+#[cfg(feature = "llvm-22")]
+use llvm_sys::{
+    core::{
+        LLVMAddCallSiteAttribute, LLVMGetArgOperand, LLVMGetCalledValue, LLVMGetNumArgOperands,
+        LLVMGetOperand, LLVMSetMetadata, LLVMSetOperand,
+    },
+    prelude::LLVMAttributeRef,
+};
+
+#[cfg(feature = "llvm-22")]
+use crate::llvm::{iter::IterDbgRecords as _, types::ir::DbgRecord};
+
+pub(crate) trait Instruction<'ctx> {
+    fn value_ref(&self) -> LLVMValueRef;
+
+    #[cfg(feature = "llvm-22")]
+    fn opcode(&self) -> LLVMOpcode {
+        unsafe { LLVMGetInstructionOpcode(self.value_ref()) }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    fn called_value(&self) -> LLVMValueRef {
+        unsafe { LLVMGetCalledValue(self.value_ref()) }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    fn num_args(&self) -> u32 {
+        unsafe { LLVMGetNumArgOperands(self.value_ref()) }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    fn args(&self) -> impl Iterator<Item = LLVMValueRef> {
+        (0..self.num_args()).map(|i| unsafe { LLVMGetArgOperand(self.value_ref(), i) })
+    }
+
+    #[cfg(feature = "llvm-22")]
+    fn dbg_records(&self) -> impl Iterator<Item = DbgRecord<'ctx>> + '_ {
+        self.value_ref()
+            .dbg_records_iter()
+            .map(|value_ref| unsafe { DbgRecord::from_dbg_record_ref(value_ref) })
+    }
+}
+
+pub(crate) enum InstructionKind<'ctx> {
+    CallInst(CallInst<'ctx>),
+    GetElementPtrInst(GetElementPtrInst<'ctx>),
+    LoadInst(LoadInst<'ctx>),
+    StoreInst(StoreInst<'ctx>),
+    Other(LLVMValueRef),
+}
+
+impl InstructionKind<'_> {
+    pub(crate) fn from_value_ref(value: LLVMValueRef) -> Self {
+        // SAFETY: We check the subclass of `Instruction`.
+        unsafe {
+            match LLVMGetInstructionOpcode(value) {
+                LLVMOpcode::LLVMCall => Self::CallInst(CallInst::from_value_ref(value)),
+                LLVMOpcode::LLVMGetElementPtr => {
+                    Self::GetElementPtrInst(GetElementPtrInst::from_value_ref(value))
+                }
+                LLVMOpcode::LLVMLoad => Self::LoadInst(LoadInst::from_value_ref(value)),
+                LLVMOpcode::LLVMStore => Self::StoreInst(StoreInst::from_value_ref(value)),
+                _ => Self::Other(value),
+            }
+        }
+    }
+
+    pub(crate) fn value_ref(&self) -> LLVMValueRef {
+        match self {
+            Self::CallInst(call_inst) => call_inst.value_ref(),
+            Self::GetElementPtrInst(gep_inst) => gep_inst.value_ref(),
+            Self::LoadInst(load_inst) => load_inst.value_ref(),
+            Self::StoreInst(store_inst) => store_inst.value_ref(),
+            Self::Other(value_ref) => *value_ref,
+        }
+    }
+}
+
+impl<'ctx> Instruction<'ctx> for InstructionKind<'ctx> {
+    fn value_ref(&self) -> LLVMValueRef {
+        Self::value_ref(self)
+    }
+}
+
+pub(crate) struct CallInst<'ctx> {
+    value_ref: LLVMValueRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+impl CallInst<'_> {
+    pub(crate) unsafe fn from_value_ref(value_ref: LLVMValueRef) -> Self {
+        Self {
+            value_ref,
+            _marker: PhantomData,
+        }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn add_attribute(&mut self, index: u32, attribute_ref: LLVMAttributeRef) {
+        unsafe {
+            LLVMAddCallSiteAttribute(self.value_ref, index, attribute_ref);
+        }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn set_metadata(&mut self, kind: u32, node: LLVMValueRef) {
+        unsafe {
+            LLVMSetMetadata(self.value_ref, kind, node);
+        }
+    }
+}
+
+impl<'ctx> Instruction<'ctx> for CallInst<'ctx> {
+    fn value_ref(&self) -> LLVMValueRef {
+        self.value_ref
+    }
+}
+
+pub(crate) struct GetElementPtrInst<'ctx> {
+    value_ref: LLVMValueRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+impl GetElementPtrInst<'_> {
+    pub(crate) unsafe fn from_value_ref(value_ref: LLVMValueRef) -> Self {
+        Self {
+            value_ref,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'ctx> Instruction<'ctx> for GetElementPtrInst<'ctx> {
+    fn value_ref(&self) -> LLVMValueRef {
+        self.value_ref
+    }
+}
+
+#[repr(u32)]
+#[cfg(feature = "llvm-22")]
+enum LoadInstOperand {
+    /// The pointer being accessed by the load instruction. Reference in
+    /// [LLVM 22][llvm-22].
+    ///
+    /// [llvm-22]: https://github.com/llvm/llvm-project/blob/llvmorg-22.1.4/llvm/include/llvm/IR/Instructions.h#L260-L261
+    Pointer = 0,
+}
+
+pub(crate) struct LoadInst<'ctx> {
+    value_ref: LLVMValueRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+impl LoadInst<'_> {
+    pub(crate) unsafe fn from_value_ref(value_ref: LLVMValueRef) -> Self {
+        Self {
+            value_ref,
+            _marker: PhantomData,
+        }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn pointer(&self) -> LLVMValueRef {
+        unsafe { LLVMGetOperand(self.value_ref, LoadInstOperand::Pointer as u32) }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn set_pointer(&mut self, value_ref: LLVMValueRef) {
+        unsafe {
+            LLVMSetOperand(self.value_ref, LoadInstOperand::Pointer as u32, value_ref);
+        }
+    }
+}
+
+impl<'ctx> Instruction<'ctx> for LoadInst<'ctx> {
+    fn value_ref(&self) -> LLVMValueRef {
+        self.value_ref
+    }
+}
+
+/// Represents the operands for a [`StoreInst`]. The enum values correspond to
+/// the operand indices within metadata index.
+#[repr(u32)]
+#[cfg(feature = "llvm-22")]
+enum StoreInstOperand {
+    /// The value being written by the store instruction. Reference in
+    /// [LLVM 22][llvm-22].
+    ///
+    /// [llvm-22]: https://github.com/llvm/llvm-project/blob/llvmorg-22.1.4/llvm/include/llvm/IR/Instructions.h#L384-L385
+    Value = 0,
+    /// The destination pointer that receives the stored value. Reference in
+    /// [LLVM 22][llvm-22].
+    ///
+    /// [llvm-22]: https://github.com/llvm/llvm-project/blob/llvmorg-22.1.4/llvm/include/llvm/IR/Instructions.h#L387-L388
+    Pointer = 1,
+}
+
+pub(crate) struct StoreInst<'ctx> {
+    value_ref: LLVMValueRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+impl StoreInst<'_> {
+    pub(crate) unsafe fn from_value_ref(value_ref: LLVMValueRef) -> Self {
+        Self {
+            value_ref,
+            _marker: PhantomData,
+        }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn value(&self) -> LLVMValueRef {
+        unsafe { LLVMGetOperand(self.value_ref, StoreInstOperand::Value as u32) }
+    }
+
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn pointer(&self) -> LLVMValueRef {
+        unsafe { LLVMGetOperand(self.value_ref, StoreInstOperand::Pointer as u32) }
+    }
+}
+
+impl<'ctx> Instruction<'ctx> for StoreInst<'ctx> {
+    fn value_ref(&self) -> LLVMValueRef {
+        self.value_ref
+    }
+}

--- a/src/llvm/types/ir.rs
+++ b/src/llvm/types/ir.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{fmt, marker::PhantomData};
 
 use llvm_sys::{
     core::{
@@ -45,8 +45,8 @@ pub(crate) enum Value<'ctx> {
     Other(LLVMValueRef),
 }
 
-impl std::fmt::Debug for Value<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Value<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MDNode(node) => f
                 .debug_struct("MDNode")
@@ -294,6 +294,14 @@ impl Drop for MetadataEntries {
 pub(crate) struct Function<'ctx> {
     pub value_ref: LLVMValueRef,
     _marker: PhantomData<&'ctx ()>,
+}
+
+impl fmt::Debug for Function<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Function")
+            .field("value", &value_to_message(self.value_ref).as_string_lossy())
+            .finish()
+    }
 }
 
 impl<'ctx> Function<'ctx> {

--- a/src/llvm/types/ir.rs
+++ b/src/llvm/types/ir.rs
@@ -17,7 +17,7 @@ use llvm_sys::{
 
 use crate::llvm::{
     LLVMContext, Message,
-    iter::IterBasicBlocks as _,
+    iter::{IterBasicBlocks as _, IterInstructions as _},
     symbol_name,
     types::di::{DICompositeType, DIDerivedType, DISubprogram, DIType},
 };
@@ -289,6 +289,34 @@ impl Drop for MetadataEntries {
     }
 }
 
+/// Represents a basic block.
+#[derive(Clone)]
+pub(crate) struct BasicBlock<'ctx> {
+    value_ref: LLVMBasicBlockRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+impl BasicBlock<'_> {
+    /// Constructs a new [`BasicBlock`] from the given basic block value.
+    ///
+    /// # Safety
+    ///
+    /// This method assumes that the provided `value_ref` corresponds to a
+    /// valid instance of [LLVM `BasicBlock`](https://llvm.org/doxygen/classllvm_1_1BasicBlock.html).
+    /// It's the caller's responsibility to ensure this invariant, as this
+    /// method doesn't perform any validation checks.
+    pub(crate) unsafe fn from_value_ref(value_ref: LLVMBasicBlockRef) -> Self {
+        Self {
+            value_ref,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn instructions(&self) -> impl Iterator<Item = LLVMValueRef> + '_ {
+        self.value_ref.instructions_iter()
+    }
+}
+
 /// Represents a function.
 #[derive(Clone)]
 pub(crate) struct Function<'ctx> {
@@ -330,8 +358,10 @@ impl<'ctx> Function<'ctx> {
         (0..params_count).map(move |i| unsafe { LLVMGetParam(value, i) })
     }
 
-    pub(crate) fn basic_blocks(&self) -> impl Iterator<Item = LLVMBasicBlockRef> + '_ {
-        self.value_ref.basic_blocks_iter()
+    pub(crate) fn basic_blocks(&self) -> impl Iterator<Item = BasicBlock<'ctx>> + '_ {
+        self.value_ref
+            .basic_blocks_iter()
+            .map(|value_ref| unsafe { BasicBlock::from_value_ref(value_ref) })
     }
 
     pub(crate) fn subprogram(&self, context: LLVMContextRef) -> Option<DISubprogram<'ctx>> {

--- a/src/llvm/types/ir.rs
+++ b/src/llvm/types/ir.rs
@@ -32,6 +32,12 @@ pub(crate) fn replace_name(
     unsafe { LLVMReplaceMDNodeOperandWith(value_ref, name_operand_index, name) };
 }
 
+pub(super) fn value_to_message(value_ref: LLVMValueRef) -> Message {
+    Message {
+        ptr: unsafe { LLVMPrintValueToString(value_ref) },
+    }
+}
+
 #[derive(Clone)]
 pub(crate) enum Value<'ctx> {
     MDNode(MDNode<'ctx>),
@@ -41,25 +47,18 @@ pub(crate) enum Value<'ctx> {
 
 impl std::fmt::Debug for Value<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let value_to_string = |value| {
-            Message {
-                ptr: unsafe { LLVMPrintValueToString(value) },
-            }
-            .as_string_lossy()
-            .to_string()
-        };
         match self {
             Self::MDNode(node) => f
                 .debug_struct("MDNode")
-                .field("value", &value_to_string(node.value_ref))
+                .field("value", &value_to_message(node.value_ref).as_string_lossy())
                 .finish(),
             Self::Function(fun) => f
                 .debug_struct("Function")
-                .field("value", &value_to_string(fun.value_ref))
+                .field("value", &value_to_message(fun.value_ref).as_string_lossy())
                 .finish(),
             Self::Other(value) => f
                 .debug_struct("Other")
-                .field("value", &value_to_string(*value))
+                .field("value", &value_to_message(*value).as_string_lossy())
                 .finish(),
         }
     }

--- a/src/llvm/types/ir.rs
+++ b/src/llvm/types/ir.rs
@@ -1,5 +1,11 @@
 use std::{fmt, marker::PhantomData};
 
+#[cfg(feature = "llvm-22")]
+use llvm_sys::{
+    LLVMDbgRecordKind,
+    core::{LLVMDbgRecordGetKind, LLVMDbgVariableRecordGetValue, LLVMDbgVariableRecordGetVariable},
+    prelude::LLVMDbgRecordRef,
+};
 use llvm_sys::{
     core::{
         LLVMCountParams, LLVMDisposeValueMetadataEntries, LLVMGetNumOperands, LLVMGetOperand,
@@ -19,7 +25,10 @@ use crate::llvm::{
     LLVMContext, Message,
     iter::{IterBasicBlocks as _, IterInstructions as _},
     symbol_name,
-    types::di::{DICompositeType, DIDerivedType, DISubprogram, DIType},
+    types::{
+        di::{DICompositeType, DIDerivedType, DISubprogram, DIType},
+        instruction::InstructionKind,
+    },
 };
 
 pub(crate) fn replace_name(
@@ -102,7 +111,11 @@ pub(crate) enum Metadata<'ctx> {
     DICompositeType(DICompositeType<'ctx>),
     DIDerivedType(DIDerivedType<'ctx>),
     DISubprogram(DISubprogram<'ctx>),
-    Other(#[expect(dead_code)] LLVMValueRef),
+    #[cfg_attr(
+        not(feature = "llvm-22"),
+        expect(dead_code, reason = "used by CO-RE support on LLVM 22")
+    )]
+    Other(LLVMValueRef),
 }
 
 impl Metadata<'_> {
@@ -289,14 +302,52 @@ impl Drop for MetadataEntries {
     }
 }
 
-/// Represents a basic block.
+#[cfg(feature = "llvm-22")]
+/// Represents a metadata node.
+#[derive(Clone)]
+pub(crate) struct DbgRecord<'ctx> {
+    value_ref: LLVMDbgRecordRef,
+    _marker: PhantomData<&'ctx ()>,
+}
+
+#[cfg(feature = "llvm-22")]
+impl DbgRecord<'_> {
+    /// Constructs a new [`DbgRecord`] from the given debug record value.
+    ///
+    /// # Safety
+    ///
+    /// This method assumes that the provided `value_ref` corresponds to a
+    /// valid instance of [LLVM `DbgRecord`](https://llvm.org/doxygen/classllvm_1_1DbgRecord.html).
+    /// It's the caller's responsibility to ensure this invariant, as this
+    /// method doesn't perform any validation checks.
+    pub(crate) unsafe fn from_dbg_record_ref(value_ref: LLVMDbgRecordRef) -> Self {
+        Self {
+            value_ref,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn kind(&self) -> LLVMDbgRecordKind {
+        unsafe { LLVMDbgRecordGetKind(self.value_ref) }
+    }
+
+    pub(crate) fn value(&self, index: u32) -> LLVMValueRef {
+        unsafe { LLVMDbgVariableRecordGetValue(self.value_ref, index) }
+    }
+
+    pub(crate) fn variable(&self) -> LLVMMetadataRef {
+        unsafe { LLVMDbgVariableRecordGetVariable(self.value_ref) }
+    }
+}
+
+/// Represents a metadata node.
 #[derive(Clone)]
 pub(crate) struct BasicBlock<'ctx> {
     value_ref: LLVMBasicBlockRef,
     _marker: PhantomData<&'ctx ()>,
 }
 
-impl BasicBlock<'_> {
+impl<'ctx> BasicBlock<'ctx> {
     /// Constructs a new [`BasicBlock`] from the given basic block value.
     ///
     /// # Safety
@@ -312,8 +363,10 @@ impl BasicBlock<'_> {
         }
     }
 
-    pub(crate) fn instructions(&self) -> impl Iterator<Item = LLVMValueRef> + '_ {
-        self.value_ref.instructions_iter()
+    pub(crate) fn instructions(&self) -> impl Iterator<Item = InstructionKind<'ctx>> + '_ {
+        self.value_ref
+            .instructions_iter()
+            .map(InstructionKind::from_value_ref)
     }
 }
 

--- a/src/llvm/types/ir_builder.rs
+++ b/src/llvm/types/ir_builder.rs
@@ -1,0 +1,54 @@
+use std::marker::PhantomData;
+
+use llvm_sys::{
+    core::{
+        LLVMBuildCall2, LLVMCreateBuilderInContext, LLVMDisposeBuilder, LLVMGlobalGetValueType,
+        LLVMPositionBuilderBefore,
+    },
+    prelude::{LLVMBuilderRef, LLVMValueRef},
+};
+
+use crate::llvm::{LLVMContext, types::instruction::CallInst};
+
+pub(crate) struct IRBuilder<'ctx> {
+    builder: LLVMBuilderRef,
+    _marker: PhantomData<&'ctx LLVMContext>,
+}
+
+impl<'ctx> IRBuilder<'ctx> {
+    pub(crate) fn new(context: &'ctx LLVMContext) -> Self {
+        let builder = unsafe { LLVMCreateBuilderInContext(context.as_mut_ptr()) };
+        Self {
+            builder,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn position_before(&self, instruction: LLVMValueRef) {
+        unsafe { LLVMPositionBuilderBefore(self.builder, instruction) };
+    }
+
+    pub(crate) fn build_call2(
+        &self,
+        callee: LLVMValueRef,
+        args: &mut [LLVMValueRef],
+    ) -> CallInst<'ctx> {
+        unsafe {
+            let value_ref = LLVMBuildCall2(
+                self.builder,
+                LLVMGlobalGetValueType(callee),
+                callee,
+                args.as_mut_ptr(),
+                args.len().try_into().unwrap(),
+                c"".as_ptr(),
+            );
+            CallInst::from_value_ref(value_ref)
+        }
+    }
+}
+
+impl Drop for IRBuilder<'_> {
+    fn drop(&mut self) {
+        unsafe { LLVMDisposeBuilder(self.builder) };
+    }
+}

--- a/src/llvm/types/mod.rs
+++ b/src/llvm/types/mod.rs
@@ -1,7 +1,12 @@
 pub(super) mod context;
+#[cfg(feature = "llvm-22")]
+pub(super) mod data_layout;
 pub(super) mod di;
 pub(super) mod di_builder;
+pub(super) mod instruction;
 pub(super) mod ir;
+#[cfg(feature = "llvm-22")]
+pub(super) mod ir_builder;
 pub(super) mod memory_buffer;
 pub(super) mod module;
 pub(super) mod target_machine;

--- a/src/llvm/types/module.rs
+++ b/src/llvm/types/module.rs
@@ -14,7 +14,7 @@ use llvm_sys::{
 use crate::llvm::{
     MemoryBuffer, Message,
     iter::{IterModuleFunctions as _, IterModuleGlobalAliases as _, IterModuleGlobals as _},
-    types::context::LLVMContext,
+    types::{context::LLVMContext, ir::Function},
 };
 
 pub(crate) struct LLVMModule<'ctx> {
@@ -88,8 +88,10 @@ impl LLVMModule<'_> {
         unsafe { LLVMStripModuleDebugInfo(self.module) != 0 }
     }
 
-    pub(crate) fn functions(&self) -> impl Iterator<Item = LLVMValueRef> {
-        self.module.functions_iter()
+    pub(crate) fn functions(&self) -> impl Iterator<Item = Function<'_>> {
+        self.module
+            .functions_iter()
+            .map(|value_ref| unsafe { Function::from_value_ref(value_ref) })
     }
 
     pub(crate) fn globals(&self) -> impl Iterator<Item = LLVMValueRef> {

--- a/src/llvm/types/module.rs
+++ b/src/llvm/types/module.rs
@@ -1,6 +1,8 @@
 use std::{ffi::CStr, marker::PhantomData};
 
 use libc::c_char;
+#[cfg(feature = "llvm-22")]
+use llvm_sys::target::LLVMGetModuleDataLayout;
 use llvm_sys::{
     bit_writer::LLVMWriteBitcodeToFile,
     core::{
@@ -11,6 +13,8 @@ use llvm_sys::{
     prelude::{LLVMModuleRef, LLVMValueRef},
 };
 
+#[cfg(feature = "llvm-22")]
+use crate::llvm::DataLayout;
 use crate::llvm::{
     MemoryBuffer, Message,
     iter::{IterModuleFunctions as _, IterModuleGlobalAliases as _, IterModuleGlobals as _},
@@ -22,7 +26,7 @@ pub(crate) struct LLVMModule<'ctx> {
     pub(super) _marker: PhantomData<&'ctx LLVMContext>,
 }
 
-impl LLVMModule<'_> {
+impl<'ctx> LLVMModule<'ctx> {
     /// Returns an unsafe mutable pointer to the LLVM module.
     ///
     /// The caller must ensure that the [`LLVMModule`] outlives the pointer this
@@ -88,7 +92,12 @@ impl LLVMModule<'_> {
         unsafe { LLVMStripModuleDebugInfo(self.module) != 0 }
     }
 
-    pub(crate) fn functions(&self) -> impl Iterator<Item = Function<'_>> {
+    #[cfg(feature = "llvm-22")]
+    pub(crate) fn data_layout(&self) -> DataLayout<'ctx> {
+        unsafe { DataLayout::from_ref(LLVMGetModuleDataLayout(self.module)) }
+    }
+
+    pub(crate) fn functions(&self) -> impl Iterator<Item = Function<'ctx>> + '_ {
         self.module
             .functions_iter()
             .map(|value_ref| unsafe { Function::from_value_ref(value_ref) })

--- a/tests/nightly/assembly/preserve-array-access-index.rs
+++ b/tests/nightly/assembly/preserve-array-access-index.rs
@@ -1,0 +1,44 @@
+// assembly-output: bpf-linker
+// compile-flags: --crate-type cdylib -C link-arg=--emit=llvm-ir -C link-arg=--btf -C debuginfo=2
+
+#![no_std]
+
+use core::{marker::PhantomData, panic::PanicInfo};
+
+#[panic_handler]
+fn panic(_info: &PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[repr(transparent)]
+pub struct Relocatable(PhantomData<()>);
+
+#[repr(C)]
+pub struct Foo {
+    a: u32,
+    b: u32,
+    c: [u32; 4],
+
+    _relocatable: Relocatable,
+}
+
+// CHECK: @"llvm.Foo:0:16$0:2:2" = external global i64, !llvm.preserve.access.index ![[FOO:[0-9]+]] #[[AMA:[0-9]+]]
+
+// CHECK-LABEL: define i32 @get_c_2(
+#[no_mangle]
+#[link_section = "uprobe/get_c_2"]
+pub unsafe extern "C" fn get_c_2(x: *const Foo) -> u32 {
+    // CHECK: %[[OFF:[0-9]+]] = load i64, ptr @"llvm.Foo:0:16$0:2:2", align 8
+    // CHECK-NEXT: %[[FIELD_PTR:[0-9]+]] = getelementptr i8, ptr %{{.*}}, i64 %[[OFF]]
+    // CHECK-NEXT: %[[PASSTHROUGH:[0-9]+]] = tail call ptr @llvm.bpf.passthrough{{.*}}(i32 {{[0-9]+}}, ptr %[[FIELD_PTR]])
+    // CHECK-NEXT: %{{.*}} = load i32, ptr %[[PASSTHROUGH]], align 4
+    (*x).c[2]
+}
+
+// CHECK: attributes #[[AMA]] = { "btf_ama" }
+// CHECK: ![[FOO]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Foo"
+// CHECK-SAME: elements: ![[FOO_ELTS:[0-9]+]]
+// CHECK: ![[FOO_ELTS]] = !{![[A:[0-9]+]], ![[B:[0-9]+]], ![[C:[0-9]+]]}
+// CHECK: ![[A]] = !DIDerivedType(tag: DW_TAG_member, name: "a"
+// CHECK: ![[B]] = !DIDerivedType(tag: DW_TAG_member, name: "b"
+// CHECK: ![[C]] = !DIDerivedType(tag: DW_TAG_member, name: "c"

--- a/tests/nightly/assembly/preserve-nested-array-access-index.rs
+++ b/tests/nightly/assembly/preserve-nested-array-access-index.rs
@@ -1,0 +1,44 @@
+// assembly-output: bpf-linker
+// compile-flags: --crate-type cdylib -C link-arg=--emit=llvm-ir -C link-arg=--btf -C debuginfo=2
+
+#![no_std]
+
+use core::{marker::PhantomData, panic::PanicInfo};
+
+#[panic_handler]
+fn panic(_info: &PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+pub struct Relocatable(PhantomData<()>);
+
+#[repr(C)]
+pub struct Bar {
+    x: u32,
+    y: u32,
+}
+
+#[repr(C)]
+pub struct Foo {
+    arr: [Bar; 4],
+
+    _marker: Relocatable,
+}
+
+// CHECK: @"llvm.Foo:0:20$0:0:2:1" = external global i64, !llvm.preserve.access.index ![[FOO:[0-9]+]] #[[AMA:[0-9]+]]
+
+// CHECK-LABEL: define i32 @get_arr_2_y(
+#[no_mangle]
+#[link_section = "uprobe/get_arr_2_y"]
+pub unsafe extern "C" fn get_arr_2_y(x: *const Foo) -> u32 {
+    // CHECK: %[[OFF:[0-9]+]] = load i64, ptr @"llvm.Foo:0:20$0:0:2:1", align 8
+    // CHECK-NEXT: %[[FIELD_PTR:[0-9]+]] = getelementptr i8, ptr %{{.*}}, i64 %[[OFF]]
+    // CHECK-NEXT: %[[PASSTHROUGH:[0-9]+]] = tail call ptr @llvm.bpf.passthrough{{.*}}(i32 {{[0-9]+}}, ptr %[[FIELD_PTR]])
+    // CHECK-NEXT: %{{.*}} = load i32, ptr %[[PASSTHROUGH]], align 4
+    (*x).arr[2].y
+}
+
+// CHECK: attributes #[[AMA]] = { "btf_ama" }
+// CHECK: ![[FOO]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Foo"

--- a/tests/nightly/assembly/preserve-struct-access-index.rs
+++ b/tests/nightly/assembly/preserve-struct-access-index.rs
@@ -1,0 +1,43 @@
+// assembly-output: bpf-linker
+// compile-flags: --crate-type cdylib -C link-arg=--emit=llvm-ir -C link-arg=--btf -C debuginfo=2
+
+#![no_std]
+
+use core::{ffi::c_void, marker::PhantomData, panic::PanicInfo};
+
+#[panic_handler]
+fn panic(_info: &PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[repr(transparent)]
+pub struct Relocatable(PhantomData<()>);
+
+#[repr(C)]
+pub struct Foo {
+    a: u32,
+    b: u32,
+
+    _relocatable: Relocatable,
+}
+
+// CHECK: @"llvm.Foo:0:4$0:1" = external global i64, !llvm.preserve.access.index ![[FOO:[0-9]+]] #[[AMA:[0-9]+]]
+
+// CHECK-LABEL: define i32 @get_b(
+#[no_mangle]
+#[link_section = "uprobe/get_b"]
+pub unsafe extern "C" fn get_b(x: *mut c_void) -> u32 {
+    let x: *const Foo = x.cast();
+    // CHECK: %[[OFF:[0-9]+]] = load i64, ptr @"llvm.Foo:0:4$0:1", align 8
+    // CHECK-NEXT: %[[FIELD_PTR:[0-9]+]] = getelementptr i8, ptr %{{.*}}, i64 %[[OFF]]
+    // CHECK-NEXT: %[[PASSTHROUGH:[0-9]+]] = tail call ptr @llvm.bpf.passthrough{{.*}}(i32 {{[0-9]+}}, ptr %[[FIELD_PTR]])
+    // CHECK-NEXT: %{{.*}} = load i32, ptr %[[PASSTHROUGH]], align 4
+    (*x).b
+}
+
+// CHECK: attributes #[[AMA]] = { "btf_ama" }
+// CHECK: ![[FOO]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Foo"
+// CHECK-SAME: elements: ![[FOO_ELTS:[0-9]+]]
+// CHECK: ![[FOO_ELTS]] = !{![[A:[0-9]+]], ![[B:[0-9]+]]}
+// CHECK: ![[A]] = !DIDerivedType(tag: DW_TAG_member, name: "a"
+// CHECK: ![[B]] = !DIDerivedType(tag: DW_TAG_member, name: "b"

--- a/tests/nightly/assembly/preserve-union-access-index.rs
+++ b/tests/nightly/assembly/preserve-union-access-index.rs
@@ -1,0 +1,40 @@
+// assembly-output: bpf-linker
+// compile-flags: --crate-type cdylib -C link-arg=--emit=llvm-ir -C link-arg=--btf -C debuginfo=2
+
+#![no_std]
+
+use core::{marker::PhantomData, panic::PanicInfo};
+
+#[panic_handler]
+fn panic(_info: &PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[repr(transparent)]
+// Union fields must not have drop side effects, deriving `Copy` achieves that.
+#[derive(Clone, Copy)]
+pub struct Relocatable(PhantomData<()>);
+
+#[repr(C)]
+pub union Foo {
+    a: u32,
+    b: u64,
+
+    _relocatable: Relocatable,
+}
+
+// CHECK: @"llvm.Foo{{.*}}" = external global i64, !llvm.preserve.access.index ![[FOO:[0-9]+]] #[[AMA:[0-9]+]]
+
+// CHECK-LABEL: define i64 @get_b(
+#[no_mangle]
+#[link_section = "uprobe/get_b"]
+pub unsafe extern "C" fn get_b(x: *const Foo) -> u64 {
+    // CHECK: %[[OFF:[0-9]+]] = load i64, ptr @"llvm.Foo{{.*}}", align 8
+    // CHECK-NEXT: %[[FIELD_PTR:[0-9]+]] = getelementptr i8, ptr %{{.*}}, i64 %[[OFF]]
+    // CHECK-NEXT: %[[PASSTHROUGH:[0-9]+]] = tail call ptr @llvm.bpf.passthrough{{.*}}(i32 {{[0-9]+}}, ptr %[[FIELD_PTR]])
+    // CHECK-NEXT: %{{.*}} = load i64, ptr %[[PASSTHROUGH]], align 8
+    (*x).b
+}
+
+// CHECK: attributes #[[AMA]] = { "btf_ama" }
+// CHECK: ![[FOO]] = !DICompositeType(tag: DW_TAG_union_type, name: "Foo"


### PR DESCRIPTION
BTF, the BPF Type Format, encodes type information for both the running Linux kernel and compiled eBPF programs. An eBPF object can carry relocation records that describe field and aggregate accesses in terms of BTF types instead of fixed offsets; at load time, the loader compares the program's BTF with the kernel's BTF and rewrites those accesses to the correct offsets for the target kernel. This mechanism is often referred to as "CO-RE relocations" or "BTF relocations".

LLVM allows to emit such relocations with the following intrinsics:

* `@llvm.preserve.array.access.index`
* `@llvm.preserve.struct.access.index`
* `@llvm.preserve.union.access.index`

When these intrinsics are preserved through codegen, LLVM emits the corresponding relocation records into the `BTF.ext` ELF section.

clang exposes this functionality through `__attribute__((preserve_access_index))` that lowers to one of the `@llvm.preserve.*.access.index` intrinsics, depending on the annotated type.

We proposed a similar mechanism for Rust[0], but that will likely take time to land. In the meantime, add support to bpf-linker using the `Relocatable` marker type: when a composite type contains a field of that marker type, treat accesses to that composite type as eligible for CO-RE relocation emission. bpf-linker then constructs the corresponding `@llvm.preserve.*.access.index` intrinsic calls using the existing debug information and lets LLVM emit the final `BTF.ext` relocation records.

[0] https://internals.rust-lang.org/t/pre-rfc-btf-relocations/24161/20

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/363)
<!-- Reviewable:end -->
