### PR TITLE
ir: Add `value_to_message` private helper

### DIFF
--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -6,6 +6,7 @@ use std::{
     borrow::Cow,
     collections::HashSet,
     ffi::{CStr, CString},
+    fmt,
     os::raw::c_char,
     ptr, slice, str,
 };
@@ -366,6 +367,12 @@ impl Message {
             .map(CStr::to_bytes)
             .map(String::from_utf8_lossy)
             .unwrap_or("<null>".into())
+    }
+}
+
+impl fmt::Debug for Message {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.as_string_lossy())
     }
 }
 

--- a/src/llvm/types/ir.rs
+++ b/src/llvm/types/ir.rs
@@ -32,6 +32,12 @@ pub(crate) fn replace_name(
     unsafe { LLVMReplaceMDNodeOperandWith(value_ref, name_operand_index, name) };
 }
 
+fn value_to_message(value_ref: LLVMValueRef) -> Message {
+    Message {
+        ptr: unsafe { LLVMPrintValueToString(value_ref) },
+    }
+}
+
 #[derive(Clone)]
 pub(crate) enum Value<'ctx> {
     MDNode(MDNode<'ctx>),
@@ -41,25 +47,18 @@ pub(crate) enum Value<'ctx> {
 
 impl std::fmt::Debug for Value<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let value_to_string = |value| {
-            Message {
-                ptr: unsafe { LLVMPrintValueToString(value) },
-            }
-            .as_string_lossy()
-            .to_string()
-        };
         match self {
             Self::MDNode(node) => f
                 .debug_struct("MDNode")
-                .field("value", &value_to_string(node.value_ref))
+                .field("value", &value_to_message(node.value_ref))
                 .finish(),
             Self::Function(fun) => f
                 .debug_struct("Function")
-                .field("value", &value_to_string(fun.value_ref))
+                .field("value", &value_to_message(fun.value_ref))
                 .finish(),
             Self::Other(value) => f
                 .debug_struct("Other")
-                .field("value", &value_to_string(*value))
+                .field("value", &value_to_message(*value))
                 .finish(),
         }
     }


### PR DESCRIPTION
The previous `value_to_string` closure was available only to the `Debug` implementation for `Value` and performed an unnecessary allocation by calling `to_string()`.

Replace it with a new helper function, `value_to_message`, that is available to the entire `types` module and can therefore be used by other LLVM wrappers as well. Return `Message`, so callers can retrieve a `Cow` by calling `as_string_lossy()`. That avoids allocations when the `Message` holds valid UTF-8.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/367)
<!-- Reviewable:end -->
