### PR TITLE
Move `LLVMEnablePrettyStackTrace` in main

### DIFF
--- a/src/bin/bpf-linker.rs
+++ b/src/bin/bpf-linker.rs
@@ -299,6 +299,19 @@ fn main() -> anyhow::Result<()> {
         linker.set_dump_module_path(path);
     }
 
+    // LLVMEnablePrettyStackTrace registers a crash handler (via
+    // sys::AddSignalHandler) and installs LLVM's fatal signal handlers.
+    // The signal handlers can eventually be torn down with
+    // sys::unregisterHandlers via a C++ shim, but there is no API to
+    // unregister the crash handler, that registration is permanent for
+    // the process.
+    //
+    // For that reason we call LLVMEnablePrettyStackTrace here and not in
+    // bpf-linker library.
+    unsafe {
+        bpf_linker::llvm_sys::error_handling::LLVMEnablePrettyStackTrace();
+    }
+
     let inputs = inputs
         .iter()
         .map(|p| LinkerInput::new_from_file(p.as_path()));

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -11,10 +11,7 @@ use std::{
 };
 
 use ar::Archive;
-use llvm_sys::{
-    error_handling::{LLVMEnablePrettyStackTrace, LLVMInstallFatalErrorHandler},
-    target_machine::LLVMCodeGenFileType,
-};
+use llvm_sys::{error_handling::LLVMInstallFatalErrorHandler, target_machine::LLVMCodeGenFileType};
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 
@@ -825,7 +822,6 @@ fn llvm_init(
 
     unsafe {
         LLVMInstallFatalErrorHandler(Some(llvm::fatal_error));
-        LLVMEnablePrettyStackTrace();
     }
 
     (context, diagnostic_handler)


### PR DESCRIPTION
Moving `LLVMEnablePrettyStackTrace` from lib to main since it is very specific to `bpf-linker` executable, library stay clean

Fix #368

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/369)
<!-- Reviewable:end -->
