### PR TITLE
release: publish split debug archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,7 +588,9 @@ jobs:
           rm -f llvm-install.tar.zst
           echo "${LLVM_INSTALL_DIR}/bin" >> $GITHUB_PATH
 
-      - uses: taiki-e/upload-rust-binary-action@v1
+      # TODO: Switch back to taiki-e/upload-rust-binary-action after split
+      # debug archive support is released upstream.
+      - uses: tamird/upload-rust-binary-action@618a41c892d3c9e19ba21ae06899385f71f4233e
         with:
           bin: bpf-linker
           target: ${{ matrix.platform.target }}
@@ -598,9 +600,10 @@ jobs:
           # defined. We want to use vanilla cargo, because we manage our own
           # clang wrappers and sysroots.
           build-tool: cargo
+          debug-archive: true
+          objcopy: objcopy
           dry-run: ${{ github.event_name != 'release' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUSTFLAGS: ${{ matrix.platform.linker && format('-C linker={0}', matrix.platform.linker) || '' }} -C target-feature=+crt-static
 
       - name: Report disk usage

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ tar -xpf bpf-linker-*.tar.gz -C "$HOME/.local/bin"
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
+Matching debug archives are published separately. For source-level
+symbolication, download the matching `.debug.tar.gz` archive on Linux or
+`.dSYM.tar.gz` archive on macOS and extract it beside the executable.
+
 [releases]: https://github.com/aya-rs/bpf-linker/releases
 
 ### Packages

--- a/build.rs
+++ b/build.rs
@@ -263,6 +263,15 @@ fn emit_search_path_if_defined(
 /// which additional libraries are required, we have to determine that set
 /// ourselves using the undefined symbols, and instruct Cargo to link them.
 fn link_llvm_static(stdout: &mut io::StdoutLock<'_>, llvm_lib_dir: &Path) -> anyhow::Result<()> {
+    // Keep LLVM archives separate so dsymutil can distinguish identically
+    // named object files.
+    let llvm_link_kind =
+        if env::var_os("CARGO_CFG_TARGET_OS").is_some_and(|target_os| target_os == "macos") {
+            "static:-bundle="
+        } else {
+            "static="
+        };
+
     // Link the library files found inside the directory.
     let dir_entries = fs::read_dir(llvm_lib_dir)
         .with_context(|| format!("failed to read directory {}", llvm_lib_dir.display()))?;
@@ -282,7 +291,13 @@ fn link_llvm_static(stdout: &mut io::StdoutLock<'_>, llvm_lib_dir: &Path) -> any
             continue;
         };
 
-        write_bytes!(stdout, "cargo:rustc-link-lib=static=LLVM", trimmed)?;
+        write_bytes!(
+            stdout,
+            "cargo:rustc-link-lib=",
+            llvm_link_kind,
+            b"LLVM",
+            trimmed
+        )?;
     }
 
     let cxxstdlibs = Cxxstdlibs::new(stdout)?;


### PR DESCRIPTION
Release binaries need debug information for source-level stack traces from
LLVM assertions, but embedding it makes the statically linked musl archives
hundreds of megabytes larger. Darwin releases had the opposite problem: the
Cargo-generated dSYM was not included in the release at all.

Publish a small runtime archive and a matching `.debug.tar.gz` or
`.dSYM.tar.gz` companion through the split-debug support in
[`618a41c`](https://github.com/tamird/upload-rust-binary-action/commit/618a41c892d3c9e19ba21ae06899385f71f4233e). The action fork is pinned until
the feature is available in an upstream release.

Keep LLVM archives separate until the final Darwin link so `dsymutil` can
distinguish identically named archive members and retain LLVM source
locations. Other support libraries keep their existing static-link behavior.
The installation documentation describes the matching debug asset.

Developed with assistance from OpenAI Codex, an LLM.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/371)
<!-- Reviewable:end -->