### PR TITLE
Split debuginfo into separate release archive

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,11 +31,11 @@ common --copt=-DNDEBUG
 
 common:release --compilation_mode=opt
 common:release --copt=-g
-common:release --copt=-flto=thin
 common:release --features=thin_lto
 common:release --strip=never
 common:release --@rules_rust//rust/settings:codegen_units=1
 common:release --@rules_rust//rust/settings:extra_rustc_flag=-Cdebuginfo=2
+common:release --@rules_rust//rust/settings:extra_rustc_flag=-Cdwarf-version=5
 common:release --@rules_rust//rust/settings:extra_rustc_flag=-Cstrip=none
 
 # Bit of rules_rust magic that is required when the C linker drives the link.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,10 +567,14 @@ jobs:
           bazel build //:release-archives "${bazel_args[@]}"
 
           mkdir -p dist
+          # Rename bazel-out/<target>-opt-.../bin/bpf-linker-release[-debuginfo].tar.zst
+          # to dist/bpf-linker-<target>[-debuginfo].tar.zst.
           while IFS= read -r src; do
             relative="${src#bazel-out/}"
-            target="${relative%%-opt/*}"
-            install -m 0644 "$src" "dist/bpf-linker-${target}.tar.zst"
+            target="${relative%%-opt*}"
+            archive_name="${src##*/}"
+            archive_suffix="${archive_name#bpf-linker-release}"
+            install -m 0644 "$src" "dist/bpf-linker-${target}${archive_suffix}"
           done < <(bazel cquery //:release-archives --output=files "${bazel_args[@]}")
 
       - name: Upload release assets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repository Instructions
+
+## Commit Messages
+
+Follow [the seven rules of a great Git commit message](https://cbea.ms/git-commit/):
+
+1. [Separate the subject from the body with a blank line](https://cbea.ms/git-commit/#separate).
+2. [Limit the subject line to 50 characters](https://cbea.ms/git-commit/#limit-50).
+3. [Capitalize the subject line](https://cbea.ms/git-commit/#capitalize).
+4. [Do not end the subject line with a period](https://cbea.ms/git-commit/#end).
+5. [Use the imperative mood in the subject line](https://cbea.ms/git-commit/#imperative).
+6. [Wrap the body at 72 characters](https://cbea.ms/git-commit/#wrap-72).
+7. [Use the body to explain what and why instead of how](https://cbea.ms/git-commit/#why-not-how).

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
@@ -7,6 +6,9 @@ load("@rules_rs//rs:rust_test.bzl", "rust_test")
 load(
     "//bazel:release.bzl",
     "bpf_linker_release",
+    "release_linux_filegroup",
+    "release_macos_filegroup",
+    "release_windows_filegroup",
 )
 
 # If Cargo.toml remaps any crate names, this tells Bazel how to pass the right
@@ -134,31 +136,49 @@ bpf_linker_release(
     binary = ":bpf-linker",
 )
 
-RELEASE_TARGETS = [
-    "%s-%s" % (arch, target_suffix)
-    for arch in [
-        "aarch64",
-        "x86_64",
-    ]
-    for target_suffix in [
-        "apple-darwin",
-        "pc-windows-gnullvm",
-        "unknown-linux-musl",
-    ]
+RELEASE_ARCHES = [
+    "aarch64",
+    "x86_64",
+]
+
+RELEASE_FILEGROUPS = {
+    "apple-darwin": release_macos_filegroup,
+    "pc-windows-gnullvm": release_windows_filegroup,
+    "unknown-linux-musl": release_linux_filegroup,
+}
+
+[
+    release_filegroup(
+        name = "release-%s-%s" % (arch, target_suffix),
+        srcs = [":bpf-linker-release"],
+        tags = ["manual"],
+        target_platform = "@rules_rs//rs/platforms:%s-%s" % (arch, target_suffix),
+    )
+    for target_suffix, release_filegroup in RELEASE_FILEGROUPS.items()
+    for arch in RELEASE_ARCHES
 ]
 
 [
-    platform_transition_filegroup(
-        name = "release-" + target,
-        srcs = [":bpf-linker-release"],
+    release_filegroup(
+        name = "release-debuginfo-%s-%s" % (arch, target_suffix),
+        srcs = [":bpf-linker-release-debuginfo"],
         tags = ["manual"],
-        target_platform = "@rules_rs//rs/platforms:" + target,
+        target_platform = "@rules_rs//rs/platforms:%s-%s" % (arch, target_suffix),
     )
-    for target in RELEASE_TARGETS
+    for target_suffix, release_filegroup in RELEASE_FILEGROUPS.items()
+    for arch in RELEASE_ARCHES
 ]
 
 filegroup(
     name = "release-archives",
-    srcs = [":release-" + target for target in RELEASE_TARGETS],
+    srcs = [
+        archive
+        for target_suffix in RELEASE_FILEGROUPS
+        for arch in RELEASE_ARCHES
+        for archive in [
+            ":release-%s-%s" % (arch, target_suffix),
+            ":release-debuginfo-%s-%s" % (arch, target_suffix),
+        ]
+    ],
     tags = ["manual"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,11 +3,11 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "llvm", version = "0.8.8")
+bazel_dep(name = "llvm", version = "0.8.9")
 bazel_dep(name = "bazel_lib", version = "3.2.2")
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.19")
-bazel_dep(name = "rules_rs", version = "0.0.89")
+bazel_dep(name = "rules_rs", version = "0.0.92")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "tar.bzl", version = "0.10.4")
 bazel_dep(name = "with_cfg.bzl", version = "0.14.6")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -87,8 +87,8 @@
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/llvm/0.8.3/MODULE.bazel": "dbc1bc13171f8f9980a75524883abef1c491613e8d8d805cd4ffa3767ba9708e",
-    "https://bcr.bazel.build/modules/llvm/0.8.8/MODULE.bazel": "c96e5ab8369bef64695269dca9ccdee97e391ea193b8715aa7c02f65401dcc7e",
-    "https://bcr.bazel.build/modules/llvm/0.8.8/source.json": "b5488a748d16724970b5714152bb75ac141559dc4b0577d4c384eafdf24a71b3",
+    "https://bcr.bazel.build/modules/llvm/0.8.9/MODULE.bazel": "9e35ff5bcac996f9edc1b44b8f8baa58c7855e742c5608b07d925dcdbe642100",
+    "https://bcr.bazel.build/modules/llvm/0.8.9/source.json": "424b907b38875f1346b65946e5e482b202b842bd3a570abbe07047d2bc7d667b",
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
     "https://bcr.bazel.build/modules/package_metadata/0.0.3/MODULE.bazel": "77890552ecea9e284b5424c9de827a58099348763a4359e975c359a83d4faa83",
     "https://bcr.bazel.build/modules/package_metadata/0.0.7/MODULE.bazel": "7adb03933fc8401f495800cf4eafcff0edc6da0ff55c7db223ef69d19f689486",
@@ -195,8 +195,8 @@
     "https://bcr.bazel.build/modules/rules_python/1.6.3/MODULE.bazel": "a7b80c42cb3de5ee2a5fa1abc119684593704fcd2fec83165ebe615dec76574f",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
-    "https://bcr.bazel.build/modules/rules_rs/0.0.89/MODULE.bazel": "14ee1c68980562692f04a3de40ab4985e1bb1d58fde01346191c5dd9b41f2a99",
-    "https://bcr.bazel.build/modules/rules_rs/0.0.89/source.json": "17d3c8c25efb225e62d523724eef4efcedd5a7e244ea93e8ce03f5188ed8374c",
+    "https://bcr.bazel.build/modules/rules_rs/0.0.92/MODULE.bazel": "192dbfb4643063187ce6b0f741df6df96c57d7d9a6979453ff50b58fed23b8e6",
+    "https://bcr.bazel.build/modules/rules_rs/0.0.92/source.json": "67b004c0288ea636ac098c7584d24d7eea526334c35758ae81225d7781275e3a",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
     "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
@@ -231,7 +231,7 @@
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
-        "usagesDigest": "v4p40Vv89DbejrKymAtZBM8gVcuVjzTMLkqUr9SsUnY=",
+        "usagesDigest": "d1uKb9PL+VNie0/I8jiQGgSQfp8nrCT2ZQiB34kUSiI=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_lib bazel_lib+",
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_skylib bazel_skylib+"
@@ -241,7 +241,7 @@
             "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
             "attributes": {
               "deps": {
-                "rules_rs": "0.0.89",
+                "rules_rs": "0.0.92",
                 "aspect_tools_telemetry": "0.3.3"
               }
             }

--- a/bazel/release.bzl
+++ b/bazel/release.bzl
@@ -1,37 +1,63 @@
 """Bazel release archive definition for bpf-linker."""
 
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@tar.bzl", "tar")
+load("@with_cfg.bzl", "with_cfg")
+
+# https://bazel.build/reference/command-line-reference#flag--fission
+release_linux_filegroup, _release_linux_filegroup_internal = with_cfg(platform_transition_filegroup).set(
+    "fission",
+    ["opt"],
+).build()
+
+# https://bazel.build/reference/command-line-reference#flag--apple_generate_dsym
+release_macos_filegroup, _release_macos_filegroup_internal = with_cfg(platform_transition_filegroup).set(
+    "apple_generate_dsym",
+    True,
+).build()
+
+# https://bazel.build/reference/command-line-reference#flag--features
+# rules_cc checks generate_pdb_file before declaring the PDB output:
+# https://github.com/bazelbuild/rules_cc/blob/0.2.19/cc/private/rules_impl/cc_binary_impl.bzl#L611-L616
+release_windows_filegroup, _release_windows_filegroup_internal = with_cfg(platform_transition_filegroup).extend(
+    "features",
+    ["generate_pdb_file"],
+).build()
 
 def bpf_linker_release(name, binary):
-    """Archives binary and its macOS dSYM directory as a zstd tar archive.
-
-    rules_rust and rules_cc emit <binary>.dSYM; the archive preserves that
-    basename.
-    """
-    dsym = name + "_dsym"
+    """Archives the binary and debug information as separate zstd archives."""
+    debug_info = name + "_debug_info"
 
     native.filegroup(
-        name = dsym,
+        name = debug_info,
         srcs = [binary],
-        # The dsym is not part of the default output group, see
-        # https://github.com/hermeticbuild/rules_rust/blob/23d5138a095ac094f5c928fa73e5a767d92dce78/rust/private/rustc.bzl#L2183
-        output_group = "dsym_folder",
+        # rules_rust creates these output groups:
+        # dwp_file: https://github.com/hermeticbuild/rules_rust/blob/8a2219c1fcf2070120c26dc67eb8aeacfc5a3819/rust/private/rustc.bzl#L2083-L2104
+        # dsym_folder: https://github.com/hermeticbuild/rules_rust/blob/8a2219c1fcf2070120c26dc67eb8aeacfc5a3819/rust/private/rustc.bzl#L1901-L1909
+        # pdb_file: https://github.com/hermeticbuild/rules_rust/blob/8a2219c1fcf2070120c26dc67eb8aeacfc5a3819/rust/private/rustc.bzl#L2059-L2062
+        output_group = select({
+            "@platforms//os:linux": "dwp_file",
+            "@platforms//os:macos": "dsym_folder",
+            "@platforms//os:windows": "pdb_file",
+        }),
         tags = ["manual"],
     )
 
-    # Release archives contain the binary at the archive root. macOS archives
-    # also contain the dSYM directory produced by the binary target.
-    # TODO(zbarsky): Confirm the dSYM archive layout, package PDB files for
-    # Windows, and package split debug information for Linux. Debug information
-    # should probably use a separate archive.
-    srcs = [binary] + select({
-        "@platforms//os:macos": [dsym],
-        "//conditions:default": [],
-    })
-
     tar(
         name = name,
-        srcs = srcs,
+        srcs = [binary],
+        args = [
+            "--options",
+            "zstd:compression-level=22",  # Max compression.
+        ],
+        compress = "zstd",
+        include_runfiles = False,
+        tags = ["manual"],
+    )
+
+    tar(
+        name = name + "-debuginfo",
+        srcs = [debug_info],
         args = [
             "--options",
             "zstd:compression-level=22",  # Max compression.


### PR DESCRIPTION
`//:release-archives` now emits separate executable and debug-information archives for each release platform: `.dwp` on Linux, `.dSYM` on macOS, and `.pdb` on Windows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/375)
<!-- Reviewable:end -->
