### PR TITLE
Prepare for release 0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bpf-linker"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpf-linker"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Alessandro Decina <alessandro.d@gmail.com>"]
 description = "BPF static linker"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Author: zbarsky-bot

Bump the bpf-linker package version to 0.10.4 before publishing the GitHub release. This release intentionally does not publish bpf-linker to crates.io.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/376)
<!-- Reviewable:end -->
