### PR TITLE
Pass public BuildBuddy key directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,12 +229,9 @@ jobs:
       - name: Test
         run: |
           set -euo pipefail
-          bazel_args=(--config=remote)
-          if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
-            bazel_args+=(--remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY")
-          fi
-
-          bazel test //... "${bazel_args[@]}"
+          bazel test //... \
+            --config=remote \
+            --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
 
   build:
     permissions:
@@ -552,15 +549,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          bazel_args=(
-            --config=release
-            --config=remote
-          )
-          if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
-            bazel_args+=(--remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY")
-          fi
-
-          bazel build //:release-archives "${bazel_args[@]}"
+          bazel build //:release-archives \
+            --config=release \
+            --config=remote \
+            --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
 
           mkdir -p dist
           # Rename bazel-out/<target>-opt-.../bin/bpf-linker-release[-debuginfo].tar.zst
@@ -571,7 +563,11 @@ jobs:
             archive_name="${src##*/}"
             archive_suffix="${archive_name#bpf-linker-release}"
             install -m 0644 "$src" "dist/bpf-linker-${target}${archive_suffix}"
-          done < <(bazel cquery //:release-archives --output=files "${bazel_args[@]}")
+          done < <(bazel cquery //:release-archives \
+            --output=files \
+            --config=release \
+            --config=remote \
+            --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY")
 
       - name: Upload release assets
         if: github.event_name == 'release'


### PR DESCRIPTION
Author: zbarsky-bot

Define the intentionally public BuildBuddy API key in the workflow environment and pass the BuildBuddy remote header directly to each Bazel command. The workflow no longer uses `secrets.BUILDBUDDY_API_KEY` or handles a missing key.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/378)
<!-- Reviewable:end -->
