### PR TITLE
Drop BuildBuddy header from cquery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,8 +566,7 @@ jobs:
           done < <(bazel cquery //:release-archives \
             --output=files \
             --config=release \
-            --config=remote \
-            --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY")
+            --config=remote)
 
       - name: Upload release assets
         if: github.event_name == 'release'


### PR DESCRIPTION
Author: zbarsky-bot

Keep the release and remote configurations on the release archive query so it selects the built outputs, but omit the BuildBuddy remote header because `cquery` does not execute remote actions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/379)
<!-- Reviewable:end -->
