### PR TITLE
Require all-green CI before merging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,3 +573,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ github.event.release.tag_name }}" dist/*
+
+  check:
+    if: always()
+    needs:
+      - llvm
+      - lint-stable
+      - lint-nightly
+      - bazel
+      - build
+      - release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Author: zbarsky-bot

Add the same `check` job used by `aya-rs/aya`. `re-actors/alls-green` aggregates every CI job into one required status so pull requests cannot merge unless the complete CI workflow succeeds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/380)
<!-- Reviewable:end -->
