### PR TITLE
cli: add cpu v4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ FLAGS:
     -V, --version                           Prints version information
 
 OPTIONS:
-        --cpu <cpu>                  Target BPF processor. Can be one of `generic`, `probe`, `v1`, `v2`, `v3` [default:
+        --cpu <cpu>                  Target BPF processor. Can be one of `generic`, `probe`, `v1`, `v2`, `v3`, `v4` [default:
                                      generic]
         --cpu-features <features>    Enable or disable CPU features. The available features are: alu32, dummy, dwarfris.
                                      LLVM 22 builds also support allows-misaligned-mem-access. Use +feature to

--- a/src/bin/bpf-linker.rs
+++ b/src/bin/bpf-linker.rs
@@ -84,7 +84,7 @@ struct CommandLine {
     #[clap(long)]
     target: Option<CString>,
 
-    /// Target BPF processor. Can be one of `generic`, `probe`, `v1`, `v2`, `v3`
+    /// Target BPF processor. Can be one of `generic`, `probe`, `v1`, `v2`, `v3`, `v4`
     #[clap(long, default_value = "generic")]
     cpu: Cpu,
 

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -96,6 +96,7 @@ pub enum Cpu {
     V1,
     V2,
     V3,
+    V4,
 }
 
 impl Cpu {
@@ -106,6 +107,7 @@ impl Cpu {
             Self::V1 => c"v1",
             Self::V2 => c"v2",
             Self::V3 => c"v3",
+            Self::V4 => c"v4",
         }
     }
 }
@@ -118,6 +120,7 @@ impl std::fmt::Display for Cpu {
             Self::V1 => "v1",
             Self::V2 => "v2",
             Self::V3 => "v3",
+            Self::V4 => "v4",
         })
     }
 }
@@ -132,6 +135,7 @@ impl FromStr for Cpu {
             "v1" => Self::V1,
             "v2" => Self::V2,
             "v3" => Self::V3,
+            "v4" => Self::V4,
             _ => return Err(LinkerError::InvalidCpu(s.to_string())),
         })
     }


### PR DESCRIPTION
tested with sbpf-linker and instructions only supported in cpu v4 are correctly generated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/386)
<!-- Reviewable:end -->
