### PR TITLE
ci: update to latest rustc LLVM 22 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           - version: 21
             git-ref: rustc/21.1-2025-08-01
           - version: 22
-            git-ref: rustc/22.1-2026-01-27
+            git-ref: rustc/22.1-2026-05-19
     steps:
       - id: ls-remote
         run: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -47,7 +47,7 @@ First, clone the LLVM sources from [our fork][llvm-fork], using the branch
 that matches the Rust toolchain you want to use. For example:
 
 ```sh
-git clone -b rustc/22.1-2026-01-27 https://github.com/aya-rs/llvm-project ./llvm-project
+git clone -b rustc/22.1-2026-05-19 https://github.com/aya-rs/llvm-project ./llvm-project
 ```
 
 If in doubt about which branch to use, check the LLVM version used by your Rust


### PR DESCRIPTION
rustc nightly fails to build one of my projects

```
error: linking with `bpf-linker` failed: exit status: 1
  |
  = note:  "bpf-linker" "--export-symbols" "/home/alessandro.linux/src/slowlana/slowlana-ebpf/../target/bpfel-unknown-none/release/deps/rustcWfde0w/symbols" "<1 object files omitted>" "-L" "/home/alessandro.linux/src/slowlana/slowlana-ebpf/../target/bpfel-unknown-none/release/deps/rustcWfde0w/raw-dylibs" "--cpu" "generic" "-o" "/home/alessandro.linux/src/slowlana/slowlana-ebpf/../target/bpfel-unknown-none/release/deps/trigger-8245b512d606773c" "-O3" "--debug"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: ERROR llvm: Invalid record (Producer: 'LLVM22.1.8-rust-1.99.0-nightly' Reader: 'LLVM 22.1.2')
          Error: failure linking module /home/alessandro.linux/src/slowlana/slowlana-ebpf/../target/bpfel-unknown-none/release/deps/trigger-8245b512d606773c.trigger.5deb2f04b527058-cgu.0.rcgu.o


warning: `slowlana-ebpf` (bin "trigger") generated 2 warnings
error: could not compile `slowlana-ebpf` (bin "trigger") due to 1 previous error; 2 warnings emitted
```

this updates CI to the latest rust-lang/llvm-project branch

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/387)
<!-- Reviewable:end -->
