### PR TITLE
[cli] allow --cpu-features to accept disabled features

### DIFF
--- a/src/bin/bpf-linker.rs
+++ b/src/bin/bpf-linker.rs
@@ -92,7 +92,12 @@ struct CommandLine {
     /// LLVM 22 builds also support allows-misaligned-mem-access. Use +feature to enable a
     /// feature, or -feature to disable it. For example
     /// --cpu-features=+allows-misaligned-mem-access,+alu32,-dwarfris
-    #[clap(long, value_name = "features", default_value = "")]
+    #[clap(
+        long,
+        value_name = "features",
+        default_value = "",
+        allow_hyphen_values = true
+    )]
     cpu_features: CString,
 
     /// Write output to <output>
@@ -395,5 +400,19 @@ mod test {
             inputs,
             [PathBuf::from("symbols.o"), PathBuf::from("rcgu.o")]
         );
+    }
+
+    #[test]
+    fn test_cpu_features_accepts_disabled_alu32() {
+        let args = [
+            "bpf-linker",
+            "symbols.o",
+            "-o",
+            "/tmp/bin.o",
+            "--cpu-features",
+            "-alu32",
+        ];
+        let CommandLine { cpu_features, .. } = Parser::parse_from(args);
+        assert_eq!(cpu_features, CString::new("-alu32").unwrap());
     }
 }


### PR DESCRIPTION
Clap interpretes values beginning with `-` as command-line flags rather than values for `--cpu-features`. Enabling `allow_hyphen_values` makes Clap accept the entire string as the option’s value.

Without the fix, if I have `"--cpu-features", "-alu32", ...`, `bpf-linker` errors out with below log

```
  error: unexpected argument '-a' found

    tip: to pass '-a' as a value, use '-- -a'

  Usage: bpf-linker [OPTIONS] --output <OUTPUT> <INPUTS>...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/390)
<!-- Reviewable:end -->
