### PR TITLE
Harden automated rustc LLVM updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ env:
   # This lets us roll out changes to the LLVM build in a pull request
   # without conflicting with artifacts produced on the main branch.
   LLVM_BUILD_REV: 3
+  LATEST_LLVM: 22
 
 permissions: {}
 
@@ -105,7 +106,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ $LLVM_VERSION == 22 ]]; then
+          if [[ $LLVM_VERSION == "$LATEST_LLVM" ]]; then
             repository=rust-lang/llvm-project
             llvm_commit=$PINNED_LLVM_COMMIT
           else
@@ -231,13 +232,13 @@ jobs:
             llvm-install.tar.zst:application/vnd.aya.llvm.install.layer.v1.tar+zstd
 
           # Candidate LLVM must not replace a version tag used by other runs.
-          if [[ ${{ matrix.llvm.version }} != 22 ]]; then
+          if [[ ${{ matrix.llvm.version }} != "$LATEST_LLVM" ]]; then
             oras tag "${{ steps.image-tag.outputs.sha }}" "${{ steps.image-tag.outputs.version }}"
           fi
 
       - name: Publish validated LLVM version
         if: >-
-          matrix.llvm.version == 22 &&
+          matrix.llvm.version == fromJSON(env.LATEST_LLVM) &&
           github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
           needs.prepare.outputs.module == ''
         run: |
@@ -366,7 +367,6 @@ jobs:
       # Features that have to be excluded when running `cargo hack --feature-powerset`
       # and intending to link dynamically.
       LLVM_EXCLUDE_FEATURES_DYNAMIC: llvm-link-static,no-llvm-linking
-      LATEST_LLVM: 22
 
     steps:
       - uses: actions/checkout@v7
@@ -426,7 +426,7 @@ jobs:
           LLVM_VERSION: ${{ matrix.toolchain.llvm }}
         run: |
           set -euxo pipefail
-          if [[ $LLVM_VERSION == 22 ]]; then
+          if [[ $LLVM_VERSION == "$LATEST_LLVM" ]]; then
             ref="${{ env.TAG_PREFIX }}:${LLVM_COMMIT}-${{ matrix.platform.target }}-${{ env.LLVM_BUILD_REV }}"
           else
             ref="${{ env.TAG_PREFIX }}:${LLVM_VERSION}-${{ matrix.platform.target }}-${{ env.LLVM_BUILD_REV }}"
@@ -448,11 +448,11 @@ jobs:
           cargo clean --target ${{ matrix.platform.target }} -p llvm-sys --release
 
       - name: Check (default features)
-        if: matrix.toolchain.llvm == env.LATEST_LLVM
+        if: matrix.toolchain.llvm == fromJSON(env.LATEST_LLVM)
         run: cargo check --target ${{ matrix.platform.target }}
 
       - name: Build (default features)
-        if: matrix.toolchain.llvm == env.LATEST_LLVM
+        if: matrix.toolchain.llvm == fromJSON(env.LATEST_LLVM)
         run: cargo build --target ${{ matrix.platform.target }}
 
       - uses: taiki-e/install-action@cargo-hack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,18 +40,7 @@ jobs:
 
       - name: Resolve the pinned rustc LLVM
         id: llvm-pin
-        run: |
-          set -euo pipefail
-
-          nightly_date=$(sed -nE 's/^# nightly-([0-9]{4}-[0-9]{2}-[0-9]{2})\.$/\1/p' MODULE.bazel)
-          llvm_commit=$(
-            sed -nE '/^llvm_source\.from_archive\(/,/^\)/s@^[[:space:]]*urls[[:space:]]*=[[:space:]]*\["https://github\.com/rust-lang/llvm-project/archive/([0-9a-f]{40})\.tar\.gz"\],[[:space:]]*$@\1@p' \
-              MODULE.bazel
-          )
-          [[ $nightly_date =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
-          [[ $llvm_commit =~ ^[0-9a-f]{40}$ ]]
-          echo "rust-nightly=nightly-$nightly_date" >> "$GITHUB_OUTPUT"
-          echo "llvm-commit=$llvm_commit" >> "$GITHUB_OUTPUT"
+        run: python3 scripts/update-rustc-llvm.py
 
       # Keep pull requests on the last validated rustc LLVM revision.
       - name: Update the pinned rustc LLVM
@@ -59,84 +48,10 @@ jobs:
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         env:
           GH_TOKEN: ${{ github.token }}
-          PINNED_LLVM_COMMIT: ${{ steps.llvm-pin.outputs.llvm-commit }}
-          PINNED_RUST_NIGHTLY: ${{ steps.llvm-pin.outputs.rust-nightly }}
         run: |
           set -euo pipefail
-
-          nightly=$(
-            curl -fsSL --retry 5 https://static.rust-lang.org/dist/channel-rust-nightly.toml |
-              yq --exit-status --input-format toml \
-                'select(.date | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")) |
-                 select(.pkg.rustc.git_commit_hash | test("^[0-9a-f]{40}$")) |
-                 "\(.date) \(.pkg.rustc.git_commit_hash)"'
-          )
-          read -r nightly_date rustc_commit <<< "$nightly"
-          [[ $nightly_date =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
-          [[ $rustc_commit =~ ^[0-9a-f]{40}$ ]]
-
-          llvm_commit=$(gh api \
-            "repos/rust-lang/rust/contents/src/llvm-project?ref=$rustc_commit" \
-            --jq 'select(.submodule_git_url == "https://github.com/rust-lang/llvm-project.git") | .sha')
-          [[ $llvm_commit =~ ^[0-9a-f]{40}$ ]]
-
-          if [[ $PINNED_RUST_NIGHTLY == "nightly-$nightly_date" &&
-                $PINNED_LLVM_COMMIT == "$llvm_commit" ]]; then
-            exit 0
-          fi
-
-          if [[ $PINNED_LLVM_COMMIT != "$llvm_commit" ]]; then
-            llvm_archive_url="https://github.com/rust-lang/llvm-project/archive/$llvm_commit.tar.gz"
-            llvm_version_url="https://raw.githubusercontent.com/rust-lang/llvm-project/$llvm_commit/cmake/Modules/LLVMVersion.cmake"
-            llvm_version=$(
-              curl -fsSL --retry 5 "$llvm_version_url" |
-                sed -nE 's/^[[:space:]]*set\(LLVM_VERSION_(MAJOR|MINOR|PATCH)[[:space:]]+([0-9]+)\)[[:space:]]*$/\2/p' |
-                paste -sd . -
-            )
-            supported_llvm_version=$(
-              sed -nE 's/^llvm_source\.version\(llvm_version = "([0-9]+\.[0-9]+\.[0-9]+)"\)$/\1/p' MODULE.bazel
-            )
-            [[ $llvm_version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
-            [[ $supported_llvm_version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
-            if [[ ${llvm_version%%.*} != "${supported_llvm_version%%.*}" ]]; then
-              echo "::notice::Rust nightly uses unsupported LLVM $llvm_version; keeping LLVM $supported_llvm_version."
-              exit 0
-            fi
-
-            archive="$RUNNER_TEMP/llvm-project.tar.gz"
-            curl -fsSL --retry 5 -o "$archive" "$llvm_archive_url"
-            LLVM_INTEGRITY="sha256-$(openssl dgst -sha256 -binary "$archive" | base64 -w0)"
-            export LLVM_INTEGRITY
-            export LLVM_VERSION="$llvm_version"
-          fi
-
-          export LLVM_COMMIT="$llvm_commit"
-          export NIGHTLY_DATE="$nightly_date"
-          perl -0pi -e '
-            s{^# nightly-\d{4}-\d{2}-\d{2}\.$}
-             {# nightly-$ENV{NIGHTLY_DATE}.}m == 1 or die "missing nightly pin\n";
-            if ($ENV{PINNED_LLVM_COMMIT} ne $ENV{LLVM_COMMIT}) {
-              s{^llvm_source\.version\(llvm_version = "[^"]+"\)$}
-               {llvm_source.version(llvm_version = "$ENV{LLVM_VERSION}")}m == 1
-                or die "missing LLVM version\n";
-              s{^    integrity = "[^"]+",$}
-               {    integrity = "$ENV{LLVM_INTEGRITY}",}m == 1
-                or die "missing LLVM integrity\n";
-              s{^    strip_prefix = "llvm-project-[0-9a-f]{40}",$}
-               {    strip_prefix = "llvm-project-$ENV{LLVM_COMMIT}",}m == 1
-                or die "missing LLVM strip prefix\n";
-              s{^    urls = \["https://github\.com/rust-lang/llvm-project/archive/[0-9a-f]{40}\.tar\.gz"\],$}
-               {    urls = ["https://github.com/rust-lang/llvm-project/archive/$ENV{LLVM_COMMIT}.tar.gz"],}m == 1
-                or die "missing LLVM archive\n";
-            }
-          ' MODULE.bazel
+          python3 scripts/update-rustc-llvm.py --update
           git diff --check
-          module=$(openssl base64 -A -in MODULE.bazel)
-          {
-            printf 'module=%s\n' "$module"
-            printf 'rust-nightly=nightly-%s\n' "$nightly_date"
-            printf 'llvm-commit=%s\n' "$llvm_commit"
-          } >> "$GITHUB_OUTPUT"
 
   llvm:
     needs: prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,6 +665,10 @@ jobs:
       - build
       - release
     runs-on: ubuntu-latest
+    # Keep Crabby's token scoped to a default-branch promotion candidate.
+    environment: >-
+      ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+          needs.prepare.outputs.module != '' && 'nightly-promotion' || 'ci' }}
     permissions:
       # Let forks update an unprotected default branch with their own token.
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -754,11 +754,12 @@ jobs:
       # Let forks update an unprotected default branch with their own token.
       contents: write
     steps:
-      - uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
+      - name: Verify all required jobs succeeded
+        env:
+          JOBS: ${{ toJSON(needs) }}
+        run: jq --exit-status 'length > 0 and all(.[]; .result == "success")' <<< "$JOBS"
 
-      # Publish only after alls-green verifies the complete CI matrix.
+      # Publish only after the complete CI matrix succeeds.
       - name: Promote the validated rustc LLVM
         if: >-
           github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&

--- a/scripts/update-rustc-llvm.py
+++ b/scripts/update-rustc-llvm.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+
+"""Inspect or update the Rust nightly and LLVM pinned by MODULE.bazel."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import tomllib
+from collections.abc import Callable
+from http.client import HTTPResponse, IncompleteRead
+from pathlib import Path
+from typing import NamedTuple
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+MODULE = Path(__file__).resolve().parent.parent / "MODULE.bazel"
+SHA = r"[0-9a-f]{40}"
+
+
+class Pin(NamedTuple):
+    nightly: str
+    commit: str
+    version: str
+
+
+def match_one(pattern: str, text: str, name: str) -> str:
+    matches = list(re.finditer(pattern, text, re.MULTILINE))
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name}")
+    return matches[0].group(1)
+
+
+def read_pin(text: str) -> Pin:
+    date = match_one(r"^# nightly-(\d{4}-\d{2}-\d{2})\.$", text, "nightly pin")
+    datetime.date.fromisoformat(date)
+    commit = match_one(
+        rf'^\s*urls = \["https://github\.com/rust-lang/'
+        rf'llvm-project/archive/({SHA})\.tar\.gz"\],\s*$',
+        text,
+        "LLVM archive",
+    )
+    prefix = match_one(
+        rf'^\s*strip_prefix = "llvm-project-({SHA})",\s*$',
+        text,
+        "LLVM strip prefix",
+    )
+    if prefix != commit:
+        raise ValueError("LLVM archive and strip prefix do not match")
+    version = match_one(
+        r'^llvm_source\.version\(llvm_version = "(\d+\.\d+\.\d+)"\)$',
+        text,
+        "LLVM version",
+    )
+    return Pin(f"nightly-{date}", commit, version)
+
+
+def open_url(url: str):
+    headers = {"User-Agent": "aya-rs/bpf-linker rustc LLVM updater"}
+    if url.startswith("https://api.github.com/") and (token := os.getenv("GH_TOKEN")):
+        headers |= {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+        }
+    return urlopen(Request(url, headers=headers), timeout=60)
+
+
+def fetch(url: str, consume: Callable[[HTTPResponse], bytes]) -> bytes:
+    for attempt in range(6):
+        try:
+            with open_url(url) as response:
+                return consume(response)
+        except HTTPError as error:
+            if attempt == 5 or not (
+                error.code in (408, 429) or 500 <= error.code < 600
+            ):
+                raise
+        except (URLError, TimeoutError, ConnectionError, IncompleteRead):
+            if attempt == 5:
+                raise
+        time.sleep(2**attempt)
+    raise AssertionError("unreachable")
+
+
+def download(url: str) -> bytes:
+    return fetch(url, lambda response: response.read())
+
+
+def resolve_latest() -> tuple[str, str]:
+    manifest = tomllib.loads(
+        download("https://static.rust-lang.org/dist/channel-rust-nightly.toml").decode()
+    )
+    date = datetime.date.fromisoformat(str(manifest["date"])).isoformat()
+    rust_commit = manifest["pkg"]["rustc"]["git_commit_hash"]
+    if not isinstance(rust_commit, str) or not re.fullmatch(SHA, rust_commit):
+        raise ValueError("nightly manifest contains an invalid rustc commit")
+    source = json.loads(
+        download(
+            "https://api.github.com/repos/rust-lang/rust/contents/"
+            f"src/llvm-project?ref={rust_commit}"
+        )
+    )
+    if (
+        source.get("submodule_git_url")
+        != "https://github.com/rust-lang/llvm-project.git"
+    ):
+        raise ValueError("rustc does not reference the expected LLVM repository")
+    commit = source["sha"]
+    if not isinstance(commit, str) or not re.fullmatch(SHA, commit):
+        raise ValueError("rustc references an invalid LLVM commit")
+    return f"nightly-{date}", commit
+
+
+def resolve_version(commit: str) -> str:
+    source = download(
+        f"https://raw.githubusercontent.com/rust-lang/llvm-project/{commit}/"
+        "cmake/Modules/LLVMVersion.cmake"
+    ).decode()
+    return ".".join(
+        match_one(
+            rf"^\s*set\(LLVM_VERSION_{part}\s+(\d+)\)\s*$",
+            source,
+            f"LLVM {part.lower()} version",
+        )
+        for part in ("MAJOR", "MINOR", "PATCH")
+    )
+
+
+def resolve_integrity(commit: str) -> str:
+    def digest_archive(archive: HTTPResponse) -> bytes:
+        digest = hashlib.sha256()
+        while chunk := archive.read(1024 * 1024):
+            digest.update(chunk)
+        if archive.length:
+            raise IncompleteRead(b"", archive.length)
+        return digest.digest()
+
+    digest = fetch(
+        f"https://github.com/rust-lang/llvm-project/archive/{commit}.tar.gz",
+        digest_archive,
+    )
+    return "sha256-" + base64.b64encode(digest).decode()
+
+
+def replace_one(text: str, pattern: str, value: str, name: str) -> str:
+    result, count = re.subn(pattern, lambda _: value, text, flags=re.MULTILINE)
+    if count != 1:
+        raise ValueError(f"expected exactly one {name}")
+    return result
+
+
+def update_module(text: str, current: Pin, nightly: str, commit: str) -> str | None:
+    if (nightly, commit) == (current.nightly, current.commit):
+        return None
+    updated = replace_one(
+        text, r"^# nightly-\d{4}-\d{2}-\d{2}\.$", f"# {nightly}.", "nightly pin"
+    )
+    if commit == current.commit:
+        return updated
+
+    version = resolve_version(commit)
+    if version.partition(".")[0] != current.version.partition(".")[0]:
+        print(
+            f"::notice::Rust nightly uses unsupported LLVM {version}; "
+            f"keeping LLVM {current.version}.",
+            file=sys.stderr,
+        )
+        return None
+    replacements = (
+        (
+            r'^llvm_source\.version\(llvm_version = "[^"]+"\)$',
+            f'llvm_source.version(llvm_version = "{version}")',
+            "LLVM version",
+        ),
+        (
+            r'^    integrity = "[^"]+",$',
+            f'    integrity = "{resolve_integrity(commit)}",',
+            "LLVM integrity",
+        ),
+        (
+            rf'^    strip_prefix = "llvm-project-{SHA}",$',
+            f'    strip_prefix = "llvm-project-{commit}",',
+            "LLVM strip prefix",
+        ),
+        (
+            rf'^    urls = \["https://github\.com/rust-lang/'
+            rf'llvm-project/archive/{SHA}\.tar\.gz"\],$',
+            f'    urls = ["https://github.com/rust-lang/llvm-project/archive/{commit}.tar.gz"],',
+            "LLVM archive",
+        ),
+    )
+    for pattern, value, name in replacements:
+        updated = replace_one(updated, pattern, value, name)
+    return updated
+
+
+def write_outputs(pin: Pin, module: str | None = None) -> None:
+    outputs = {
+        "rust-nightly": pin.nightly,
+        "llvm-commit": pin.commit,
+        "llvm-version": pin.version,
+    }
+    if module is not None:
+        outputs["module"] = base64.b64encode(module.encode()).decode()
+    rendered = "".join(f"{key}={value}\n" for key, value in outputs.items())
+    print(rendered, end="")
+    if output := os.getenv("GITHUB_OUTPUT"):
+        with open(output, "a", encoding="utf-8") as destination:
+            destination.write(rendered)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="update MODULE.bazel to the latest supported Rust nightly",
+    )
+    args = parser.parse_args()
+    try:
+        text = MODULE.read_text(encoding="utf-8")
+        pin = read_pin(text)
+        if not args.update:
+            write_outputs(pin)
+        elif updated := update_module(text, pin, *resolve_latest()):
+            candidate = read_pin(updated)
+            MODULE.write_text(updated, encoding="utf-8")
+            write_outputs(candidate, updated)
+        return 0
+    except (IncompleteRead, KeyError, OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow up on #389 by making rustc LLVM advancement readable, fail-closed, and safe for protected-branch promotion.

Replace embedded shell and Perl with an independently executable, standard-library-only nightly and LLVM updater. Preserve bounded retries for transient network failures, restart and rehash interrupted or truncated archive downloads, use explicit UTF-8 for file I/O, reject malformed or unsupported candidates before writing, and centralize the newest supported LLVM version. Keep bpf-linker and Bazel on stable Rust; use the pinned nightly only for Aya BPF integration.

Replace the mutable third-party matrix gate with a first-party, fail-closed jq check. Expose the protected-branch bot token only to an actual default-branch update through the main-restricted nightly-promotion environment, and retain exact-head compare-and-swap. Pull requests, forks, unchanged pins, and non-default branches remain unprivileged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/391)
<!-- Reviewable:end -->