### PR TITLE
Match Aya Bazel memory and concurrency limits

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -62,9 +62,10 @@ common:remote --action_env=PATH=/bin:/usr/bin
 common:remote --remote_cache_compression
 common:remote --remote_download_toplevel
 
-# Keep remote backends fed
+# Keep remote backends fed; throttling also waits for remote uploads.
+# https://github.com/bazelbuild/bazel/issues/28734
 common:remote --noexperimental_throttle_remote_action_building
-common:remote --jobs=800
+common:remote --jobs=400
 
 # Tell Bazel how to build for our remote platform. Note that `--platforms`
 # defaults to the host platform, so the 2nd line is needed to make sure that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,8 @@ jobs:
       - name: Test
         run: |
           set -euo pipefail
-          bazel test //... \
+          # The default JVM heap is under 2 GB on 7 GB macOS runners.
+          bazel --host_jvm_args=-Xmx4g test //... \
             --config=remote \
             --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
 


### PR DESCRIPTION
The previous 800-job remote execution limit can exhaust native threads on 7 GB macOS runners. Match Aya's 400-job limit and increase the CI JVM heap to 4 GB.

Keep remote-action throttling disabled because its semaphore also covers remote input uploads and unnecessarily limits remote throughput [1].

[1]: https://github.com/bazelbuild/bazel/issues/28734

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/393)
<!-- Reviewable:end -->
