### PR TITLE
Use Aya's resolved nightly to update LLVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     types: [published]
 
   schedule:
-    # Run the full CI matrix and advance the tested nightly at 04:00 UTC.
+    # Validate the committed nightly and external dependencies every day.
     - cron: 00 4 * * *
 
 env:
@@ -27,32 +27,25 @@ permissions: {}
 
 jobs:
   prepare:
-    name: prepare rustc LLVM
+    name: resolve rustc LLVM
     runs-on: ubuntu-latest
     permissions:
-      # Read the checkout and rustc's LLVM submodule.
       contents: read
     outputs:
-      module: ${{ steps.llvm-update.outputs.module }}
-      llvm-commit: ${{ steps.llvm-update.outputs.llvm-commit || steps.llvm-pin.outputs.llvm-commit }}
-      rust-nightly: ${{ steps.llvm-update.outputs.rust-nightly || steps.llvm-pin.outputs.rust-nightly }}
+      rust-nightly: ${{ steps.pin.outputs.rust-nightly }}
+      llvm-commit: ${{ steps.pin.outputs.llvm-commit }}
     steps:
       - uses: actions/checkout@v7
 
-      - name: Resolve the pinned rustc LLVM
-        id: llvm-pin
-        run: python3 scripts/update-rustc-llvm.py
-
-      # Keep pull requests on the last validated rustc LLVM revision.
-      - name: Update the pinned rustc LLVM
-        id: llvm-update
-        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Resolve the committed Rust nightly and LLVM
+        id: pin
         run: |
           set -euo pipefail
-          python3 scripts/update-rustc-llvm.py --update
-          git diff --check
+
+          pin=$(python3 scripts/rustc-llvm.py current < MODULE.bazel)
+          read -r nightly commit <<< "$pin"
+          printf 'rust-nightly=%s\nllvm-commit=%s\n' \
+            "$nightly" "$commit" >> "$GITHUB_OUTPUT"
 
   llvm:
     needs: prepare
@@ -239,8 +232,7 @@ jobs:
       - name: Publish validated LLVM version
         if: >-
           matrix.llvm.version == fromJSON(env.LATEST_LLVM) &&
-          github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
-          needs.prepare.outputs.module == ''
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           set -euxo pipefail
           oras tag "${{ steps.image-tag.outputs.sha }}" "${{ steps.image-tag.outputs.version }}"
@@ -288,13 +280,6 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v7
-
-      # Each job has its own checkout; test the exact proposed module.
-      - name: Apply the rustc LLVM candidate
-        if: needs.prepare.outputs.module != ''
-        env:
-          MODULE: ${{ needs.prepare.outputs.module }}
-        run: printf '%s' "$MODULE" | openssl base64 -d -A > MODULE.bazel
 
       - name: Test
         run: |
@@ -621,12 +606,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Apply the rustc LLVM candidate
-        if: needs.prepare.outputs.module != ''
-        env:
-          MODULE: ${{ needs.prepare.outputs.module }}
-        run: printf '%s' "$MODULE" | openssl base64 -d -A > MODULE.bazel
-
       - name: Build release
         run: |
           set -euo pipefail
@@ -666,64 +645,8 @@ jobs:
       - build
       - release
     runs-on: ubuntu-latest
-    # Keep Crabby's token scoped to a default-branch promotion candidate.
-    environment: >-
-      ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
-          needs.prepare.outputs.module != '' && 'nightly-promotion' || 'ci' }}
-    permissions:
-      # Let forks update an unprotected default branch with their own token.
-      contents: write
     steps:
       - name: Verify all required jobs succeeded
         env:
-          JOBS: ${{ toJSON(needs) }}
-        run: jq --exit-status 'length > 0 and all(.[]; .result == "success")' <<< "$JOBS"
-
-      # Publish only after the complete CI matrix succeeds.
-      - name: Promote the validated rustc LLVM
-        if: >-
-          github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
-          needs.prepare.outputs.module != ''
-        env:
-          BASE_COMMIT: ${{ github.sha }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          # Prefer Crabby for protected branches; forks use their own token.
-          GH_TOKEN: ${{ secrets.CRABBY_GITHUB_TOKEN || github.token }}
-          LLVM_COMMIT: ${{ needs.prepare.outputs.llvm-commit }}
-          MODULE: ${{ needs.prepare.outputs.module }}
-          RUST_NIGHTLY: ${{ needs.prepare.outputs.rust-nightly }}
-        run: |
-          set -euo pipefail
-
-          # Compare-and-swap the tested commit, not just the LLVM: a merge
-          # starts a new default-branch run that must validate the candidate.
-          jq -n \
-            --arg module "$MODULE" \
-            --arg repository "$GITHUB_REPOSITORY" \
-            --arg branch "$DEFAULT_BRANCH" \
-            --arg expected "$BASE_COMMIT" \
-            --arg headline "Update rustc LLVM to ${RUST_NIGHTLY#nightly-}" \
-            --arg llvm "$LLVM_COMMIT" \
-            '{
-              query: "mutation AdvanceRustcLlvm($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
-              variables: {
-                input: {
-                  branch: {
-                    repositoryNameWithOwner: $repository,
-                    branchName: $branch
-                  },
-                  expectedHeadOid: $expected,
-                  message: {
-                    headline: $headline,
-                    body: "Match the validated Aya integration nightly to rustc LLVM commit\n\($llvm)."
-                  },
-                  fileChanges: {
-                    additions: [
-                      {path: "MODULE.bazel", contents: $module}
-                    ]
-                  }
-                }
-              }
-            }' |
-            gh api graphql --input - \
-              --jq '.data.createCommitOnBranch.commit | "\(.oid) \(.url)"'
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: jq --exit-status 'length > 0 and all(.[]; . == "success")' <<< "$RESULTS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,36 +23,24 @@ env:
   LLVM_BUILD_REV: 3
   LATEST_LLVM: 22
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Promoting a nightly pushes to main and starts another CI run.
+  # Do not let that new run cancel the promotion that started it.
+  cancel-in-progress: >-
+    ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+
 permissions: {}
 
 jobs:
   prepare:
     name: prepare rustc LLVM
-    runs-on: ubuntu-latest
+    uses: aya-rs/aya/.github/workflows/nightly-prepare.yml@8e70cde875d8c77a44c1c6736e5aab8937eb3ae3
     permissions:
       # Read the checkout and rustc's LLVM submodule.
       contents: read
-    outputs:
-      module: ${{ steps.llvm-update.outputs.module }}
-      llvm-commit: ${{ steps.llvm-update.outputs.llvm-commit || steps.llvm-pin.outputs.llvm-commit }}
-      rust-nightly: ${{ steps.llvm-update.outputs.rust-nightly || steps.llvm-pin.outputs.rust-nightly }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Resolve the pinned rustc LLVM
-        id: llvm-pin
-        run: python3 scripts/update-rustc-llvm.py
-
-      # Keep pull requests on the last validated rustc LLVM revision.
-      - name: Update the pinned rustc LLVM
-        id: llvm-update
-        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          python3 scripts/update-rustc-llvm.py --update
-          git diff --check
+    with:
+      updater-script: scripts/update-rustc-llvm.py
 
   llvm:
     needs: prepare
@@ -102,7 +90,8 @@ jobs:
         env:
           LLVM_VERSION: ${{ matrix.llvm.version }}
           LLVM_REF: ${{ matrix.llvm.git-ref }}
-          PINNED_LLVM_COMMIT: ${{ needs.prepare.outputs.llvm-commit }}
+          # The shared provider treats LLVM state as caller-owned metadata.
+          PINNED_LLVM_COMMIT: ${{ fromJSON(needs.prepare.outputs.metadata).commit }}
         run: |
           set -euo pipefail
 
@@ -423,7 +412,7 @@ jobs:
 
       - name: Restore LLVM from ghcr.io
         env:
-          LLVM_COMMIT: ${{ needs.prepare.outputs.llvm-commit }}
+          LLVM_COMMIT: ${{ fromJSON(needs.prepare.outputs.metadata).commit }}
           LLVM_VERSION: ${{ matrix.toolchain.llvm }}
         run: |
           set -euxo pipefail
@@ -676,54 +665,22 @@ jobs:
     steps:
       - name: Verify all required jobs succeeded
         env:
-          JOBS: ${{ toJSON(needs) }}
-        run: jq --exit-status 'length > 0 and all(.[]; .result == "success")' <<< "$JOBS"
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: jq --exit-status 'length > 0 and all(.[]; . == "success")' <<< "$RESULTS"
 
       # Publish only after the complete CI matrix succeeds.
       - name: Promote the validated rustc LLVM
         if: >-
           github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
           needs.prepare.outputs.module != ''
+        uses: aya-rs/aya/.github/actions/promote-nightly@8e70cde875d8c77a44c1c6736e5aab8937eb3ae3
         env:
-          BASE_COMMIT: ${{ github.sha }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           # Prefer Crabby for protected branches; forks use their own token.
           GH_TOKEN: ${{ secrets.CRABBY_GITHUB_TOKEN || github.token }}
-          LLVM_COMMIT: ${{ needs.prepare.outputs.llvm-commit }}
-          MODULE: ${{ needs.prepare.outputs.module }}
-          RUST_NIGHTLY: ${{ needs.prepare.outputs.rust-nightly }}
-        run: |
-          set -euo pipefail
-
-          # Compare-and-swap the tested commit, not just the LLVM: a merge
-          # starts a new default-branch run that must validate the candidate.
-          jq -n \
-            --arg module "$MODULE" \
-            --arg repository "$GITHUB_REPOSITORY" \
-            --arg branch "$DEFAULT_BRANCH" \
-            --arg expected "$BASE_COMMIT" \
-            --arg headline "Update rustc LLVM to ${RUST_NIGHTLY#nightly-}" \
-            --arg llvm "$LLVM_COMMIT" \
-            '{
-              query: "mutation AdvanceRustcLlvm($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
-              variables: {
-                input: {
-                  branch: {
-                    repositoryNameWithOwner: $repository,
-                    branchName: $branch
-                  },
-                  expectedHeadOid: $expected,
-                  message: {
-                    headline: $headline,
-                    body: "Match the validated Aya integration nightly to rustc LLVM commit\n\($llvm)."
-                  },
-                  fileChanges: {
-                    additions: [
-                      {path: "MODULE.bazel", contents: $module}
-                    ]
-                  }
-                }
-              }
-            }' |
-            gh api graphql --input - \
-              --jq '.data.createCommitOnBranch.commit | "\(.oid) \(.url)"'
+        with:
+          module: ${{ needs.prepare.outputs.module }}
+          rust-nightly: ${{ needs.prepare.outputs.rust-nightly }}
+          headline-prefix: Update rustc LLVM to
+          body: |-
+            Match the validated Aya integration nightly to rustc LLVM commit
+            ${{ fromJSON(needs.prepare.outputs.metadata).commit }}.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,79 @@
+name: Update Rust nightly
+
+on:
+  push:
+    branches:
+      - main
+
+  schedule:
+    - cron: 00 3 * * *
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: aya-rs/aya/.github/workflows/nightly-update.yml@15a0de1b363e51d55d0fca4245df54a61e8d5521
+
+  update:
+    needs: nightly
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    # Keep one promotion running and only the newest promotion pending.
+    concurrency: nightly-promotion
+    # Only main can enter this environment and use its Crabby credential.
+    environment: nightly-promotion
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Update the rustc LLVM
+        id: update
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          nightly='${{ needs.nightly.outputs.rust-nightly }}'
+          module=$(python3 scripts/rustc-llvm.py update "$nightly" < MODULE.bazel)
+          if [[ -n "$module" ]]; then
+            printf '%s\n' "$module" > MODULE.bazel
+            pin=$(python3 scripts/rustc-llvm.py current < MODULE.bazel)
+            read -r nightly commit <<< "$pin"
+            printf 'date=%s\nllvm-commit=%s\n' \
+              "${nightly#nightly-}" "$commit" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update the Rust nightly pull request
+        id: pull-request
+        if: steps.update.outputs.date != ''
+        uses: peter-evans/create-pull-request@v8
+        with:
+          # GitHub requires approval before GITHUB_TOKEN-created PRs run CI.
+          # Crabby starts required checks automatically so updates auto-merge.
+          # Forks use GITHUB_TOKEN and approve their checks manually.
+          token: ${{ secrets.CRABBY_GITHUB_TOKEN || github.token }}
+          branch: create-pull-request/rust-nightly
+          add-paths: MODULE.bazel
+          commit-message: |-
+            Update rustc LLVM to ${{ steps.update.outputs.date }}
+
+            Match the Aya integration nightly to rustc LLVM commit
+            ${{ steps.update.outputs.llvm-commit }}.
+          title: 'Update rustc LLVM to ${{ steps.update.outputs.date }}'
+          body: |-
+            Match the Aya integration nightly to rustc LLVM commit
+            ${{ steps.update.outputs.llvm-commit }}.
+
+      - name: Enable auto-merge
+        # Forks do not receive the Crabby token required for auto-merge.
+        if: >-
+          !github.event.repository.fork &&
+          steps.pull-request.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.CRABBY_GITHUB_TOKEN }}
+          PULL_REQUEST: ${{ steps.pull-request.outputs.pull-request-number }}
+        run: gh pr merge "$PULL_REQUEST" --auto --rebase

--- a/scripts/rustc-llvm.py
+++ b/scripts/rustc-llvm.py
@@ -8,6 +8,7 @@ import argparse
 import base64
 import datetime
 import hashlib
+import itertools
 import json
 import os
 import re
@@ -16,13 +17,11 @@ import time
 import tomllib
 from collections.abc import Callable
 from http.client import HTTPResponse, IncompleteRead
-from pathlib import Path
 from typing import NamedTuple
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 
-MODULE = Path(__file__).resolve().parent.parent / "MODULE.bazel"
 SHA = r"[0-9a-f]{40}"
 
 
@@ -63,7 +62,7 @@ def read_pin(text: str) -> Pin:
     return Pin(f"nightly-{date}", commit, version)
 
 
-def open_url(url: str):
+def open_url(url: str) -> HTTPResponse:
     headers = {"User-Agent": "aya-rs/bpf-linker rustc LLVM updater"}
     if url.startswith("https://api.github.com/") and (token := os.getenv("GH_TOKEN")):
         headers |= {
@@ -74,7 +73,7 @@ def open_url(url: str):
 
 
 def fetch(url: str, consume: Callable[[HTTPResponse], bytes]) -> bytes:
-    for attempt in range(6):
+    for attempt in itertools.count():
         try:
             with open_url(url) as response:
                 return consume(response)
@@ -87,18 +86,21 @@ def fetch(url: str, consume: Callable[[HTTPResponse], bytes]) -> bytes:
             if attempt == 5:
                 raise
         time.sleep(2**attempt)
-    raise AssertionError("unreachable")
 
 
 def download(url: str) -> bytes:
     return fetch(url, lambda response: response.read())
 
 
-def resolve_latest() -> tuple[str, str]:
+def resolve_commit(nightly: str) -> str:
+    date = nightly.removeprefix("nightly-")
     manifest = tomllib.loads(
-        download("https://static.rust-lang.org/dist/channel-rust-nightly.toml").decode()
+        download(
+            f"https://static.rust-lang.org/dist/{date}/channel-rust-nightly.toml"
+        ).decode()
     )
-    date = datetime.date.fromisoformat(str(manifest["date"])).isoformat()
+    if manifest.get("date") != date:
+        raise ValueError("nightly manifest does not match the pinned date")
     rust_commit = manifest["pkg"]["rustc"]["git_commit_hash"]
     if not isinstance(rust_commit, str) or not re.fullmatch(SHA, rust_commit):
         raise ValueError("nightly manifest contains an invalid rustc commit")
@@ -116,7 +118,7 @@ def resolve_latest() -> tuple[str, str]:
     commit = source["sha"]
     if not isinstance(commit, str) or not re.fullmatch(SHA, commit):
         raise ValueError("rustc references an invalid LLVM commit")
-    return f"nightly-{date}", commit
+    return commit
 
 
 def resolve_version(commit: str) -> str:
@@ -160,6 +162,7 @@ def replace_one(text: str, pattern: str, value: str, name: str) -> str:
 def update_module(text: str, current: Pin, nightly: str, commit: str) -> str | None:
     if (nightly, commit) == (current.nightly, current.commit):
         return None
+
     updated = replace_one(
         text, r"^# nightly-\d{4}-\d{2}-\d{2}\.$", f"# {nightly}.", "nightly pin"
     )
@@ -167,13 +170,12 @@ def update_module(text: str, current: Pin, nightly: str, commit: str) -> str | N
         return updated
 
     version = resolve_version(commit)
-    if version.partition(".")[0] != current.version.partition(".")[0]:
-        print(
-            f"::notice::Rust nightly uses unsupported LLVM {version}; "
-            f"keeping LLVM {current.version}.",
-            file=sys.stderr,
+    major = current.version.partition(".")[0]
+    if version.partition(".")[0] != major:
+        raise ValueError(
+            f"Rust nightly {nightly} uses unsupported LLVM {version}; "
+            f"expected LLVM major {major}"
         )
-        return None
     replacements = (
         (
             r'^llvm_source\.version\(llvm_version = "[^"]+"\)$',
@@ -202,43 +204,32 @@ def update_module(text: str, current: Pin, nightly: str, commit: str) -> str | N
     return updated
 
 
-def write_outputs(pin: Pin, module: str | None = None) -> None:
-    outputs = {
-        "rust-nightly": pin.nightly,
-        "llvm-commit": pin.commit,
-        "llvm-version": pin.version,
-    }
-    if module is not None:
-        outputs["module"] = base64.b64encode(module.encode()).decode()
-    rendered = "".join(f"{key}={value}\n" for key, value in outputs.items())
-    print(rendered, end="")
-    if output := os.getenv("GITHUB_OUTPUT"):
-        with open(output, "a", encoding="utf-8") as destination:
-            destination.write(rendered)
-
-
-def main() -> int:
+def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--update",
-        action="store_true",
-        help="update MODULE.bazel to the latest supported Rust nightly",
-    )
-    args = parser.parse_args()
-    try:
-        text = MODULE.read_text(encoding="utf-8")
-        pin = read_pin(text)
-        if not args.update:
-            write_outputs(pin)
-        elif updated := update_module(text, pin, *resolve_latest()):
-            candidate = read_pin(updated)
-            MODULE.write_text(updated, encoding="utf-8")
-            write_outputs(candidate, updated)
-        return 0
-    except (IncompleteRead, KeyError, OSError, ValueError) as error:
-        print(f"error: {error}", file=sys.stderr)
-        return 1
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("current")
+    update = commands.add_parser("update")
+    update.add_argument("nightly")
+    arguments = parser.parse_args()
+
+    text = sys.stdin.read()
+    pin = read_pin(text)
+    if arguments.command == "current":
+        print(pin.nightly, pin.commit)
+        return
+
+    nightly = arguments.nightly
+    match = re.fullmatch(r"nightly-(\d{4}-\d{2}-\d{2})", nightly)
+    if match is None:
+        raise ValueError("expected a dated Rust nightly")
+    datetime.date.fromisoformat(match.group(1))
+    if nightly < pin.nightly:
+        raise ValueError(f"Rust nightly regressed from {pin.nightly} to {nightly}")
+
+    if updated := update_module(text, pin, nightly, resolve_commit(nightly)):
+        read_pin(updated)
+        sys.stdout.write(updated)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/scripts/update-rustc-llvm.py
+++ b/scripts/update-rustc-llvm.py
@@ -4,39 +4,17 @@
 
 from __future__ import annotations
 
-import argparse
 import base64
 import datetime
 import hashlib
 import json
-import os
 import re
 import sys
-import time
-import tomllib
-from collections.abc import Callable
 from http.client import HTTPResponse, IncompleteRead
 from pathlib import Path
-from typing import NamedTuple
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from typing import Any
 
-
-MODULE = Path(__file__).resolve().parent.parent / "MODULE.bazel"
-SHA = r"[0-9a-f]{40}"
-
-
-class Pin(NamedTuple):
-    nightly: str
-    commit: str
-    version: str
-
-
-def match_one(pattern: str, text: str, name: str) -> str:
-    matches = list(re.finditer(pattern, text, re.MULTILINE))
-    if len(matches) != 1:
-        raise ValueError(f"expected exactly one {name}")
-    return matches[0].group(1)
+from nightly import Pin, SHA, download, fetch, main, match_one, replace_one
 
 
 def read_pin(text: str) -> Pin:
@@ -60,45 +38,10 @@ def read_pin(text: str) -> Pin:
         text,
         "LLVM version",
     )
-    return Pin(f"nightly-{date}", commit, version)
+    return Pin(f"nightly-{date}", {"commit": commit, "version": version})
 
 
-def open_url(url: str):
-    headers = {"User-Agent": "aya-rs/bpf-linker rustc LLVM updater"}
-    if url.startswith("https://api.github.com/") and (token := os.getenv("GH_TOKEN")):
-        headers |= {
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-        }
-    return urlopen(Request(url, headers=headers), timeout=60)
-
-
-def fetch(url: str, consume: Callable[[HTTPResponse], bytes]) -> bytes:
-    for attempt in range(6):
-        try:
-            with open_url(url) as response:
-                return consume(response)
-        except HTTPError as error:
-            if attempt == 5 or not (
-                error.code in (408, 429) or 500 <= error.code < 600
-            ):
-                raise
-        except (URLError, TimeoutError, ConnectionError, IncompleteRead):
-            if attempt == 5:
-                raise
-        time.sleep(2**attempt)
-    raise AssertionError("unreachable")
-
-
-def download(url: str) -> bytes:
-    return fetch(url, lambda response: response.read())
-
-
-def resolve_latest() -> tuple[str, str]:
-    manifest = tomllib.loads(
-        download("https://static.rust-lang.org/dist/channel-rust-nightly.toml").decode()
-    )
-    date = datetime.date.fromisoformat(str(manifest["date"])).isoformat()
+def resolve_commit(manifest: dict[str, Any]) -> str:
     rust_commit = manifest["pkg"]["rustc"]["git_commit_hash"]
     if not isinstance(rust_commit, str) or not re.fullmatch(SHA, rust_commit):
         raise ValueError("nightly manifest contains an invalid rustc commit")
@@ -116,7 +59,7 @@ def resolve_latest() -> tuple[str, str]:
     commit = source["sha"]
     if not isinstance(commit, str) or not re.fullmatch(SHA, commit):
         raise ValueError("rustc references an invalid LLVM commit")
-    return f"nightly-{date}", commit
+    return commit
 
 
 def resolve_version(commit: str) -> str:
@@ -150,27 +93,23 @@ def resolve_integrity(commit: str) -> str:
     return "sha256-" + base64.b64encode(digest).decode()
 
 
-def replace_one(text: str, pattern: str, value: str, name: str) -> str:
-    result, count = re.subn(pattern, lambda _: value, text, flags=re.MULTILINE)
-    if count != 1:
-        raise ValueError(f"expected exactly one {name}")
-    return result
-
-
-def update_module(text: str, current: Pin, nightly: str, commit: str) -> str | None:
-    if (nightly, commit) == (current.nightly, current.commit):
+def update_module(
+    text: str, current: Pin, nightly: str, manifest: dict[str, Any]
+) -> str | None:
+    commit = resolve_commit(manifest)
+    if (nightly, commit) == (current.nightly, current.metadata["commit"]):
         return None
     updated = replace_one(
         text, r"^# nightly-\d{4}-\d{2}-\d{2}\.$", f"# {nightly}.", "nightly pin"
     )
-    if commit == current.commit:
+    if commit == current.metadata["commit"]:
         return updated
 
     version = resolve_version(commit)
-    if version.partition(".")[0] != current.version.partition(".")[0]:
+    if version.partition(".")[0] != current.metadata["version"].partition(".")[0]:
         print(
             f"::notice::Rust nightly uses unsupported LLVM {version}; "
-            f"keeping LLVM {current.version}.",
+            f"keeping LLVM {current.metadata['version']}.",
             file=sys.stderr,
         )
         return None
@@ -202,43 +141,7 @@ def update_module(text: str, current: Pin, nightly: str, commit: str) -> str | N
     return updated
 
 
-def write_outputs(pin: Pin, module: str | None = None) -> None:
-    outputs = {
-        "rust-nightly": pin.nightly,
-        "llvm-commit": pin.commit,
-        "llvm-version": pin.version,
-    }
-    if module is not None:
-        outputs["module"] = base64.b64encode(module.encode()).decode()
-    rendered = "".join(f"{key}={value}\n" for key, value in outputs.items())
-    print(rendered, end="")
-    if output := os.getenv("GITHUB_OUTPUT"):
-        with open(output, "a", encoding="utf-8") as destination:
-            destination.write(rendered)
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--update",
-        action="store_true",
-        help="update MODULE.bazel to the latest supported Rust nightly",
-    )
-    args = parser.parse_args()
-    try:
-        text = MODULE.read_text(encoding="utf-8")
-        pin = read_pin(text)
-        if not args.update:
-            write_outputs(pin)
-        elif updated := update_module(text, pin, *resolve_latest()):
-            candidate = read_pin(updated)
-            MODULE.write_text(updated, encoding="utf-8")
-            write_outputs(candidate, updated)
-        return 0
-    except (IncompleteRead, KeyError, OSError, ValueError) as error:
-        print(f"error: {error}", file=sys.stderr)
-        return 1
-
-
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(
+        main(Path(__file__).resolve().parent.parent / "MODULE.bazel", read_pin, update_module)
+    )


### PR DESCRIPTION
Update bpf-linker's nightly and matching LLVM revision from Aya's latest available nightly candidate.

Depends on aya-rs/aya#1656.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/394)
<!-- Reviewable:end -->
