### PR TITLE
Update rustc LLVM to 2026-08-13

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ single_version_override(
 )
 
 # @llvm-project uses the rust-lang/llvm-project commit referenced by
-# nightly-2026-08-12.
+# nightly-2026-08-13.
 llvm = use_extension("@llvm//extensions:llvm.bzl", "llvm")
 
 # llvm.version only sets generated LLVM version constants; from_archive


### PR DESCRIPTION
Match the Aya integration nightly to rustc LLVM commit
21cf28432798952d942bacc6bcee3a328faa3638.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/400)
<!-- Reviewable:end -->
