### PR TITLE
fix(bazel): Report correct version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,25 @@ jobs:
             oras tag "$sha" "$version"
           done
 
+  check-version:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Generate version.bzl
+        run: ./bazel/version/gen_version_bzl.sh > version.bzl.new
+
+      - name: Check version.bzl is in sync
+        run: |
+          if ! diff -u bazel/version/version.bzl version.bzl.new; then
+            echo "ERROR: version.bzl is out of sync with Cargo.toml"
+            echo "Run: bash bazel/version/gen_version_bzl.sh > bazel/version/version.bzl"
+            exit 1
+          fi
+
   lint-stable:
     runs-on: ubuntu-latest
 
@@ -543,6 +562,7 @@ jobs:
       - bazel
       - build
       - release
+      - check-version
     runs-on: ubuntu-latest
     steps:
       - name: Verify all required jobs succeeded

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,7 @@ load(
     "release_windows_filegroup",
 )
 load("//bazel:llvm_archive.bzl", "llvm_archive", "llvm_archive_for_platform")
+load("//bazel/version:version.bzl", "BPF_LINKER_VERSION")
 
 # If Cargo.toml remaps any crate names, this tells Bazel how to pass the right
 # `--extern` flags.
@@ -129,6 +130,7 @@ rust_library(
     aliases = CRATE_ALIASES,
     crate_features = CRATE_FEATURES,
     crate_name = "bpf_linker",
+    rustc_env = {"CARGO_PKG_VERSION": BPF_LINKER_VERSION},
     visibility = ["//visibility:public"],
     deps = CRATE_DEPS,
 )
@@ -140,6 +142,7 @@ rust_binary(
     crate_features = CRATE_FEATURES,
     crate_name = "bpf_linker",
     crate_root = "src/bin/bpf-linker.rs",
+    rustc_env = {"CARGO_PKG_VERSION": BPF_LINKER_VERSION},
     visibility = ["//visibility:public"],
     deps = CRATE_DEPS + [":bpf-linker-lib"],
 )
@@ -161,6 +164,7 @@ rust_test(
     crate_features = CRATE_FEATURES,
     crate_name = "bpf_linker",
     crate_root = "src/bin/bpf-linker.rs",
+    rustc_env = {"CARGO_PKG_VERSION": BPF_LINKER_VERSION},
     deps = TEST_DEPS + [":bpf-linker-lib"],
 )
 

--- a/bazel/version/BUILD.bazel
+++ b/bazel/version/BUILD.bazel
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/bazel/version/gen_version_bzl.sh
+++ b/bazel/version/gen_version_bzl.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Generate version.bzl from Cargo.toml
+# Usage: gen_version_bzl.sh > version.bzl
+
+CARGO_TOML="$(dirname "$0")/../..//Cargo.toml"
+VERSION=$(grep '^version' "$CARGO_TOML" | sed 's/version = "\([^"]*\)"/\1/')
+
+cat <<EOF
+"""Version constants for bpf-linker.
+
+WARNING: This file is auto-generated from Cargo.toml.
+Do not edit manually - run gen_version_bzl.sh instead.
+"""
+
+BPF_LINKER_VERSION = "$VERSION"
+EOF

--- a/bazel/version/version.bzl
+++ b/bazel/version/version.bzl
@@ -1,0 +1,7 @@
+"""Version constants for bpf-linker.
+
+WARNING: This file is auto-generated from Cargo.toml.
+Do not edit manually - run gen_version_bzl.sh instead.
+"""
+
+BPF_LINKER_VERSION = "0.11.0"


### PR DESCRIPTION
Bazel-built binaries were reporting `--version` as 0.0.0 instead of 0.11.0 because `CARGO_PKG_VERSION` was not set. Add version.bzl module and make sure it's kept in sync with Cargo.toml. Pass the version from version.bzl in `rustc_env`.

Fixes: #401

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/402)
<!-- Reviewable:end -->
