### PR TITLE
Read Bazel crate versions from Cargo.toml

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@cargo_toml_version//:version.bzl", "VERSION")
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
@@ -129,6 +130,7 @@ rust_library(
     aliases = CRATE_ALIASES,
     crate_features = CRATE_FEATURES,
     crate_name = "bpf_linker",
+    version = VERSION,
     visibility = ["//visibility:public"],
     deps = CRATE_DEPS,
 )
@@ -140,6 +142,7 @@ rust_binary(
     crate_features = CRATE_FEATURES,
     crate_name = "bpf_linker",
     crate_root = "src/bin/bpf-linker.rs",
+    version = VERSION,
     visibility = ["//visibility:public"],
     deps = CRATE_DEPS + [":bpf-linker-lib"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,16 @@ bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "tar.bzl", version = "0.10.4")
 bazel_dep(name = "with_cfg.bzl", version = "0.14.6")
 
+cargo_toml_version = use_repo_rule(
+    "//bazel:cargo_toml_version.bzl",
+    "cargo_toml_version",
+)
+
+cargo_toml_version(
+    name = "cargo_toml_version",
+    cargo_toml = "//:Cargo.toml",
+)
+
 # @llvm-project uses the rust-lang/llvm-project commit referenced by
 # nightly-2026-08-18.
 llvm = use_extension("@llvm//extensions:llvm.bzl", "llvm")

--- a/bazel/cargo_toml_version.bzl
+++ b/bazel/cargo_toml_version.bzl
@@ -1,0 +1,20 @@
+"""Expose the Cargo package version to Bazel Rust targets."""
+
+load("@rules_rs//rs/private:toml2json.bzl", "run_toml2json")
+
+def _cargo_toml_version_impl(rctx):
+    cargo_toml = rctx.path(rctx.attr.cargo_toml)
+    rctx.watch(cargo_toml)
+
+    version = run_toml2json(rctx, cargo_toml)["package"]["version"]
+    rctx.file("BUILD.bazel", executable = False)
+    rctx.file("version.bzl", "VERSION = %s\n" % json.encode(version), executable = False)
+
+    return rctx.repo_metadata(reproducible = True)
+
+cargo_toml_version = repository_rule(
+    implementation = _cargo_toml_version_impl,
+    attrs = {
+        "cargo_toml": attr.label(allow_single_file = True, mandatory = True),
+    },
+)


### PR DESCRIPTION
Smuggle the version from Cargo.toml through a repository rule to make it loadable in BUILD.bazel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/411)
<!-- Reviewable:end -->
