### PR TITLE
Validate the Rust resolver before promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
             --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
 
       - name: Publish LLVM OCI artifact
+        # Build jobs fetch commit-tagged archives, so same-repo PRs must be
+        # able to publish them when selecting a new LLVM commit.
+        #
         # GitHub does not allow foreign-repository pull requests to push
         # container images. Attempting to do so fails with:
         #
@@ -145,7 +148,13 @@ jobs:
         #
         # Disable artifact publishing for forked pull requests. This
         # restriction is a reasonable security measure.
-        if: steps.artifact-restore.outputs.missing == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: >-
+          steps.artifact-restore.outputs.missing == 'true' &&
+          (
+            github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
+            github.event_name == 'release' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
         env:
           LLVM_COMMIT: ${{ fromJSON(needs.prepare.outputs.llvm)[matrix.llvm].commit }}
         working-directory: bazel-bin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,10 @@
 name: Update Rust toolchains
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/nightly.yml
+
   push:
     branches:
       - main
@@ -11,16 +15,17 @@ on:
 
 jobs:
   resolve:
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     permissions:
       contents: read
     # Shared Rust channel discovery (aya-rs/aya#1688).
-    uses: aya-rs/aya/.github/workflows/rust-toolchains.yml@3e2478226f9b4509a06b0b753c0ed28c1876dca1
+    uses: aya-rs/aya/.github/workflows/rust-toolchains.yml@c29cd71cb4fe1440bc0d566633afa822f1b41fc5
     with:
       channels: stable beta nightly
 
   update:
     needs: resolve
+    if: >-
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Fix the updater's unusable Aya workflow pin and validate the resolver call in PRs. Make publication conditions explicit.

— Codex, on behalf of @tamird

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/413)
<!-- Reviewable:end -->
