### PR TITLE
Include Rust versions in toolchain PR titles

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,7 +74,10 @@ jobs:
             ${{ steps.update.outputs.llvm-commit }}.
             Test Rust ${{ fromJSON(steps.update.outputs.toolchains).stable.rust }} with LLVM ${{ fromJSON(steps.update.outputs.toolchains).stable.llvm }}.
             Test ${{ fromJSON(steps.update.outputs.toolchains).beta.rust }} with LLVM ${{ fromJSON(steps.update.outputs.toolchains).beta.llvm }}.
-          title: Update Rust toolchains
+          title: >-
+            Update Rust ${{ fromJSON(steps.update.outputs.toolchains).stable.rust }},
+            ${{ fromJSON(steps.update.outputs.toolchains).beta.rust }},
+            ${{ fromJSON(steps.update.outputs.toolchains).nightly.rust }}
           body: |-
             Update the pinned Rust toolchains and their LLVM selections.
 


### PR DESCRIPTION
Show the selected stable, beta, and nightly versions in generated update PR titles.

— Codex, on behalf of @tamird

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/bpf-linker/414)
<!-- Reviewable:end -->
